### PR TITLE
workaround VSCode BetterJinja syntax highlighting

### DIFF
--- a/dbt/include/sqlserver/macros/adapters.sql
+++ b/dbt/include/sqlserver/macros/adapters.sql
@@ -25,10 +25,11 @@
 
 {% macro sqlserver__create_schema(database_name, schema_name) -%}
   {% call statement('create_schema') -%}
-    USE {{ database_name }}
-    IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = {{ schema_name | replace('"', "'") }})
+    {%- set quote_none = schema_name | replace('"', "") -%}
+    {%- set quote_single = schema_name | replace('"', "'") -%}
+    IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = {{quote_single}})
     BEGIN
-    EXEC('CREATE SCHEMA {{ schema_name | replace('"', "") }}')
+    EXEC('CREATE SCHEMA {{quote_none}}')
     END
   {% endcall %}
 {% endmacro %}


### PR DESCRIPTION
break apart line 31 which contained 4 `'`'s and 3 `"`'s. 
I opened this issue (https://github.com/samuelcolvin/jinjahtml-vscode/issues/59) so perhaps there's a better way to do this, but this was one way that worked for me.