### PR TITLE
drop macro sqlserver__drop_relation()

### DIFF
--- a/dbt/include/sqlserver/macros/adapters.sql
+++ b/dbt/include/sqlserver/macros/adapters.sql
@@ -39,12 +39,6 @@
   {% endcall %}
 {% endmacro %}
 
-{% macro sqlserver__drop_relation(relation) -%}
-  {% call statement('drop_relation', auto_begin=False) -%}
-    drop {{ relation.type }} if exists {{ relation.schema }}.{{ relation.identifier }}
-  {%- endcall %}
-{% endmacro %}
-
 {% macro sqlserver__drop_relation_script(relation) -%}
     drop {{ relation.type }} if exists {{ relation.schema }}.{{ relation.identifier }}
 {% endmacro %}


### PR DESCRIPTION
my first thought was to make `sqlserver__drop_relation` just a wrapper for `sqlserver__drop_relation_script`, but then I looked and found it isn't ever used...