### PR TITLE
HOTFIX break conflict w/ dbt-external-tables testing

### DIFF
--- a/test/integration/azuresql.dbtspec
+++ b/test/integration/azuresql.dbtspec
@@ -7,7 +7,7 @@ target:
   database: "{{ env_var('DBT_AZURESQL_DB') }}"
   username: "{{ env_var('DBT_AZURESQL_UID') }}"
   password: "{{ env_var('DBT_AZURESQL_PWD') }}"
-  schema: dbt_external_tables_integration_tests_azuresql
+  schema: "dbt_test_azure_sql_{{ var('_dbt_random_suffix') }}"
   encrypt: yes
   trust_cert: yes
   threads: 1


### PR DESCRIPTION
we're getting [an error](https://app.circleci.com/pipelines/github/dbt-msft/dbt-sqlserver/47/workflows/e06e2e39-13cf-4213-b401-015ee510f512/jobs/129) for the azuresql testing, because I ignorantly gave the azuresql target the same schema as is used for testing in the dbt-external-tables repo...
```
  ('42000', "[42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Cannot drop schema 'dbt_external_tables_integration_tests_azuresql' because it is being referenced by object 'people_csv_unpartitioned'. (3729) (SQLExecDirectW)")
```

let's see if this does anything for us.
