### PR TITLE
Hotfix  serverless sql

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,13 +112,11 @@ jobs:
 workflows:
   main:
     jobs:
-      # - unit
+      - unit
       - connection-azuresql: &profile
           context:
             - DBT_SYNAPSE_PROFILE
-      # - connection-sqlserver: *profile
-      # - integration-sqlserver: *profile
+      - connection-sqlserver: *profile
+      - integration-sqlserver: *profile
       - integration-azuresql:
           <<: *profile
-          # requires:
-          #   - connection-azuresql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,13 +112,13 @@ jobs:
 workflows:
   main:
     jobs:
-      - unit
-      - connection-azuresql: &profile
-          context:
-            - DBT_SYNAPSE_PROFILE
-      - connection-sqlserver: *profile
-      - integration-sqlserver: *profile
+      # - unit
+      # - connection-azuresql: &profile
+      #     context:
+      #       - DBT_SYNAPSE_PROFILE
+      # - connection-sqlserver: *profile
+      # - integration-sqlserver: *profile
       - integration-azuresql:
           <<: *profile
-          requires:
-            - connection-azuresql
+          # requires:
+          #   - connection-azuresql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,4 +113,7 @@ workflows:
             - DBT_SYNAPSE_PROFILE
       - connection-sqlserver: *profile
       - integration-sqlserver: *profile
-      - integration-azuresql: *profile
+      - integration-azuresql:
+          <<: *profile
+          requires:
+            - connection-azuresql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,3 +120,5 @@ workflows:
       - integration-sqlserver: *profile
       - integration-azuresql:
           <<: *profile
+          requires:
+            - connection-azuresql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,11 @@ jobs:
       - azure-cli/install
       - run: *prep=connect
       - run:
+          name: wake up server
+          command: |
+            cd test/integration
+            dbt debug --target azuresql_sqlcred
+      - run:
           name: cnxn -- Azure SQL - SQL CRED user+pass
           command: |
             cd test/integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,9 +113,9 @@ workflows:
   main:
     jobs:
       # - unit
-      # - connection-azuresql: &profile
-      #     context:
-      #       - DBT_SYNAPSE_PROFILE
+      - connection-azuresql: &profile
+          context:
+            - DBT_SYNAPSE_PROFILE
       # - connection-sqlserver: *profile
       # - integration-sqlserver: *profile
       - integration-azuresql:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.19.0.3
+
+#### under the hood
+- allow CI to work with the lower-cost serverless Azure SQL [#132](https://github.com/dbt-msft/dbt-sqlserver/pull/132)
 ### v0.19.0.2
 
 #### fixes

--- a/test/integration/azuresql.dbtspec
+++ b/test/integration/azuresql.dbtspec
@@ -18,7 +18,8 @@ projects:
       config-version: 2
       version: '1.0.0'
       models:
-        +as_columnstore: false
+        dbt_test_project:
+          +as_columnstore: false
   - overrides: ephemeral
     dbt_project_yml: *override-project
   - overrides: incremental

--- a/test/integration/azuresql.dbtspec
+++ b/test/integration/azuresql.dbtspec
@@ -19,7 +19,8 @@ projects:
       version: '1.0.0'
       models:
         dbt_test_project:
-          +as_columnstore: false  - overrides: ephemeral
+          +as_columnstore: false 
+  - overrides: ephemeral
     dbt_project_yml: *override-project
   - overrides: incremental
     dbt_project_yml: *override-project

--- a/test/integration/azuresql.dbtspec
+++ b/test/integration/azuresql.dbtspec
@@ -13,8 +13,13 @@ target:
   threads: 1
 projects:
   - overrides: base
-    dbt_project_yml: '{"name":"schema_tests","config-version": 2, "version": "1.0.0", "models": {"dbt_test_project": {"as_columnstore": "false"}}}' &override-project
-  - overrides: ephemeral
+    dbt_project_yml: &override-project
+      name: schema_tests
+      config-version: 2
+      version: '1.0.0'
+      models:
+        dbt_test_project:
+          +as_columnstore: false  - overrides: ephemeral
     dbt_project_yml: *override-project
   - overrides: incremental
     dbt_project_yml: *override-project

--- a/test/integration/azuresql.dbtspec
+++ b/test/integration/azuresql.dbtspec
@@ -13,7 +13,7 @@ target:
   threads: 1
 projects:
   - overrides: base
-    dbt_project_yml: '{"name":"dbt_test_project","config-version": 2, "version": "1.0.0", "models": {"dbt_test_project": {"as_columnstore": "false"}}}' &override-project
+    dbt_project_yml: '{"name":"schema_tests","config-version": 2, "version": "1.0.0", "models": {"dbt_test_project": {"as_columnstore": "false"}}}' &override-project
   - overrides: ephemeral
     dbt_project_yml: *override-project
   - overrides: incremental

--- a/test/integration/azuresql.dbtspec
+++ b/test/integration/azuresql.dbtspec
@@ -13,13 +13,17 @@ target:
   threads: 1
 projects:
   - overrides: base
-    dbt_project_yml: &override-project
-      name: dbt_test_project
-      config-version: 2
-      version: '1.0.0'
-      models:
-        dbt_test_project:
-          +as_columnstore: false
+    dbt_project_yml: | &override-project
+      {
+          "name":"dbt_test_project",
+          "config-version": 2,
+          "version": "1.0.0",
+          "models": {
+          "dbt_test_project": {
+            "as_columnstore": "false"
+            }
+          }
+      }
   - overrides: ephemeral
     dbt_project_yml: *override-project
   - overrides: incremental

--- a/test/integration/azuresql.dbtspec
+++ b/test/integration/azuresql.dbtspec
@@ -25,7 +25,7 @@ projects:
     dbt_project_yml: *override-project
   - overrides: snapshot_strategy_timestamp
     dbt_project_yml: *override-project
-  - overrides: schema_test
+  - overrides: schema_tests
     dbt_project_yml: *override-project
 sequences:
   test_dbt_empty: empty

--- a/test/integration/azuresql.dbtspec
+++ b/test/integration/azuresql.dbtspec
@@ -13,17 +13,7 @@ target:
   threads: 1
 projects:
   - overrides: base
-    dbt_project_yml: | &override-project
-      {
-          "name":"dbt_test_project",
-          "config-version": 2,
-          "version": "1.0.0",
-          "models": {
-          "dbt_test_project": {
-            "as_columnstore": "false"
-            }
-          }
-      }
+    dbt_project_yml: '{"name":"dbt_test_project","config-version": 2, "version": "1.0.0", "models": {"dbt_test_project": {"as_columnstore": "false"}}}' &override-project
   - overrides: ephemeral
     dbt_project_yml: *override-project
   - overrides: incremental

--- a/test/integration/azuresql.dbtspec
+++ b/test/integration/azuresql.dbtspec
@@ -11,6 +11,22 @@ target:
   encrypt: yes
   trust_cert: yes
   threads: 1
+projects:
+  - overrides: base
+    dbt_project_yml: &override-project
+      name: dbt_test_project
+      config-version: 2
+      version: '1.0.0'
+      models:
+        +as_columnstore: false
+  - overrides: ephemeral
+    dbt_project_yml: *override-project
+  - overrides: incremental
+    dbt_project_yml: *override-project
+  - overrides: snapshot_strategy_timestamp
+    dbt_project_yml: *override-project
+  - overrides: schema_test
+    dbt_project_yml: *override-project
 sequences:
   test_dbt_empty: empty
   test_dbt_base: base

--- a/test/integration/azuresql.dbtspec
+++ b/test/integration/azuresql.dbtspec
@@ -26,6 +26,8 @@ projects:
     dbt_project_yml: *override-project
   - overrides: snapshot_strategy_timestamp
     dbt_project_yml: *override-project
+  - overrides: snapshot_strategy_check_cols
+    dbt_project_yml: *override-project
   - overrides: schema_tests
     dbt_project_yml: *override-project
 sequences:
@@ -34,7 +36,7 @@ sequences:
   test_dbt_ephemeral: ephemeral
   test_dbt_incremental: incremental
   test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
-  # test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols
+  test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols
   test_dbt_data_test: data_test
   test_dbt_schema_test: schema_test
   # test_dbt_ephemeral_data_tests: data_test_ephemeral_models

--- a/test/integration/dbt_project.yml
+++ b/test/integration/dbt_project.yml
@@ -4,7 +4,3 @@ version: '1.0'
 config-version: 2
 
 profile: 'integration_tests'
-
-models:
-  sqlserver_integration_tests:
-    +as_columnstore: false

--- a/test/integration/dbt_project.yml
+++ b/test/integration/dbt_project.yml
@@ -4,3 +4,7 @@ version: '1.0'
 config-version: 2
 
 profile: 'integration_tests'
+
+models:
+  sqlserver_integration_tests:
+    +as_columnstore: false


### PR DESCRIPTION
Azure SQL Standard Tier is more expensive than hopefully needed. To make Azure SQL serverless work, I:
- disabled the default `columnstore` option, and
- made the `connection-azuresql` job come before the `integration-azuresql` job to ensure that the serverless db is unpaused/active before connecting