### PR TITLE
drop unecessary& broken code from ADIntegrated connection option

### DIFF
--- a/dbt/adapters/sqlserver/connections.py
+++ b/dbt/adapters/sqlserver/connections.py
@@ -270,9 +270,6 @@ class SQLServerConnectionManager(SQLConnectionManager):
                     con_str.append(f"PWD={{{credentials.PWD}}}")
                 elif type_auth == "ActiveDirectoryInteractive":
                     con_str.append(f"UID={{{credentials.UID}}}")
-                elif type_auth == "ActiveDirectoryIntegrated":
-                    # why is this necessary???
-                    con_str.remove("UID={None}")
                 elif type_auth == "ActiveDirectoryMsi":
                     raise ValueError("ActiveDirectoryMsi is not supported yet")
 


### PR DESCRIPTION
drop unneeded debugging code that only was run when "Active Directory integrated" was given as the auth method
fixes: #148 