### PR TITLE
fix index with columns containing spaces

### DIFF
--- a/dbt/include/sqlserver/macros/indexes.sql
+++ b/dbt/include/sqlserver/macros/indexes.sql
@@ -132,7 +132,7 @@ end
 
 {{ log("Creating nonclustered index...") }}
 
-{% set idx_name = this.table + '__index_on_' + columns|join('_') %}
+{% set idx_name = this.table + '__index_on_' + columns|join('_')|replace(" ", "_") %}
 
 if not exists(select * from sys.indexes 
                 where 


### PR DESCRIPTION
if columns contains space then index name built from the name contains space as well. Fixed with space replaced to underscore.