### PR TITLE
Creating indexes in the indexes section of a model config

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ models:
 ```
 
 Supported parameters:
-- `type`: index type, accepted values: `clustered`, `nonclustered`, `clustered columnstore`, `nonclustered columnstore`
+- `type` (**required**): index type, accepted values: `clustered`, `nonclustered`, `clustered columnstore`, `nonclustered columnstore`
 - `columns`: columns list in index
 - `unique`: index uniquiness
 - `include_columns`: include columns list for nonclustered indexes
@@ -249,6 +249,17 @@ Examples:
     ]
 )}}
 ```
+
+Matrix of compatibility of parameters and index types:
+| Parameter / Index type                                       | CLUSTERED | NONCLUSTERED | CLUSTERED COLUMNSTORE | NONCLUSTERED COLUMNSTORE |
+| ------------------------------------------------------------ | --------- | ------------ | --------------------- | ------------------------ |
+| `columns`                                                    | ✅         | ✅            | ❌                     | ✅                        |
+| `unique`                                                     | ✅         | ✅            | ❌                     | ❌                        |
+| `include_columns`                                            | ❌         | ✅            | ❌                     | ❌                        |
+| `partition_schema`                                           | ✅         | ✅            | ❌                     | ✅                        |
+| `partition_column`                                           | ✅         | ✅            | ❌                     | ✅                        |
+| `data_compression` (`ROW` and `PAGE`)                        | ✅         | ✅            | ❌                     | ❌                        |
+| `data_compression` (`COLUMNSTORE` and `COLUMNSTORE_ARCHIVE`) | ❌         | ❌            | ✅                     | ✅                        |
 
 ### Indexes (old-way)
 

--- a/README.md
+++ b/README.md
@@ -237,15 +237,15 @@ Supported parameters:
 Examples:
 ```sql
 {{ config(
-    materialized = 'table',
-    as_columnstore: false,
-    indexes=[
-        {'type': 'clustered', 'columns': ['customer_id'], 'unique': True},
-        {'type': 'nonclustered', 'columns': ['number_of_orders'], 'include_columns': ['first_order']},
-        {'type': 'clustered columnstore'},
-        {'type': 'nonclustered columnstore', 'columns': ['customer_id', 'first_name', 'last_name']}
-        {'type': 'nonclustered', 'columns': ['customer_id'], 'partition_schema': 'ps_by_month',
-          'partition_column': 'order_date', 'data_compression': 'page'}
+    materialized = "table",
+    as_columnstore = false,
+    indexes = [
+        {"type": "clustered", "columns": ["customer_id"], "unique": True},
+        {"type": "nonclustered", "columns": ["number_of_orders"], "include_columns": ["first_order"]},
+        {"type": "clustered columnstore"},
+        {"type": "nonclustered columnstore", "columns": ["customer_id", "first_name", "last_name"]}
+        {"type": "nonclustered", "columns": ["customer_id"], "partition_schema": "ps_by_month",
+          "partition_column": "order_date", "data_compression": "page"}
     ]
 )}}
 ```

--- a/README.md
+++ b/README.md
@@ -216,6 +216,42 @@ Many DBT utils macros are supported, but they require the addition of the `tsql_
 You can find the package and installation instructions in the [tsql-utils repo](https://github.com/dbt-msft/tsql-utils).
 
 ### Indexes
+There is now possible to define a regular sql server index on a table in `indexes` section of model configuration.
+To use that way for creating indexes you need to disable `as_columnstore` in model configuration.
+You can do this in `dbt_project.yml` for the whole project or for the model personally.
+```yaml
+models:
+  my_project:
+    +as_columnstore: false
+```
+
+Supported parameters:
+- `type`: index type, accepted values: `clustered`, `nonclustered`, `clustered columnstore`, `nonclustered columnstore`
+- `columns`: columns list in index
+- `unique`: index uniquiness
+- `include_columns`: include columns list for nonclustered indexes
+- `partition_schema`: partition schema name for partitioning
+- `partition_column`: partition column name for partitioning
+- `data_compression`: data compression for indexes, accepted values: `row`, `page`, `columnstore`, `columnstore_archive` 
+
+Examples:
+```sql
+{{ config(
+    materialized = 'table',
+    as_columnstore: false,
+    indexes=[
+        {'type': 'clustered', 'columns': ['customer_id'], 'unique': True},
+        {'type': 'nonclustered', 'columns': ['number_of_orders'], 'include_columns': ['first_order']},
+        {'type': 'clustered columnstore'},
+        {'type': 'nonclustered columnstore', 'columns': ['customer_id', 'first_name', 'last_name']}
+        {'type': 'nonclustered', 'columns': ['customer_id'], 'partition_schema': 'ps_by_month',
+          'partition_column': 'order_date', 'data_compression': 'page'}
+    ]
+)}}
+```
+
+### Indexes (old-way)
+
 There is now possible to define a regular sql server index on a table. 
 This is best used when the default clustered columnstore index materialisation is not suitable. 
 One reason would be that you need a large table that usually is queried one row at a time.

--- a/dbt/adapters/sqlserver/impl.py
+++ b/dbt/adapters/sqlserver/impl.py
@@ -119,7 +119,7 @@ class SQLServerIndexConfig(dbtClassMixin):
             dbt.exceptions.raise_compiler_error(
                 f'Invalid index config:\n'
                 f'  Got: {raw_index}\n'
-                f'  Expected a dictionary with at minimum a "columns" key'
+                f'  Expected a dictionary with at minimum a "type" key'
             )
 
 @dataclass

--- a/dbt/adapters/sqlserver/impl.py
+++ b/dbt/adapters/sqlserver/impl.py
@@ -62,6 +62,12 @@ class SQLServerIndexConfig(dbtClassMixin):
                     f'  Got: {ix_config.type}\n'
                     f'  type should be either: "clustered", "nonclustered", "clustered columnstore", "nonclustered columnstore"'
                 )
+            # Check columns parameter
+            elif ix_type not in ['clustered columnstore'] and not ix_config.columns:
+                dbt.exceptions.raise_compiler_error(
+                    f'The "columns" parameter is required for all types of indexes (except clustered columnstore).\n'
+                    f'  Add the "columns" parameter.'
+                )
             # Columns parameter doesn't work with clustered columnstore indexes
             elif ix_type in ['clustered columnstore'] and ix_config.columns:
                 dbt.exceptions.raise_compiler_error(

--- a/dbt/adapters/sqlserver/impl.py
+++ b/dbt/adapters/sqlserver/impl.py
@@ -88,17 +88,17 @@ class SQLServerIndexConfig(dbtClassMixin):
                 )
             # Check data compression parameter
             elif (ix_config.data_compression
-                and ix_data_compression not in ['page', 'row', 'columnstore', 'columnstore_archive']):
+                and ix_data_compression not in ['row', 'page', 'columnstore', 'columnstore_archive']):
                 dbt.exceptions.raise_compiler_error(
                     f'Invalid data compression:\n'
                     f'  Got: {ix_config.data_compression}\n'
-                    f'  data compression should be either: "page", "row", "columnstore", "columnstore_archive"'
+                    f'  data compression should be either: "row", "page", "columnstore", "columnstore_archive"'
                 )
             # Data compression for row-store indexes
-            elif (ix_data_compression in ['page', 'row']
+            elif (ix_data_compression in ['row', 'page']
                 and ix_type not in ['clustered', 'nonclustered']):
                 dbt.exceptions.raise_compiler_error(
-                    f'PAGE and ROW data compression works only with row-store indexes.\n'
+                    f'ROW and PAGE data compression works only with row-store indexes.\n'
                     f'  Remove or fix the "data_compression" parameter.'
                 )
             # Data compression for columnstore indexes

--- a/dbt/include/sqlserver/macros/adapters/indexes.sql
+++ b/dbt/include/sqlserver/macros/adapters/indexes.sql
@@ -29,7 +29,7 @@
       include ({{ "[" + index_config.include_columns|join("], [") + "]" }})
     {%- endif %}
     {% if index_config.data_compression -%}
-      with (data_compression = {{ data_compression }})
+      with (data_compression = {{ index_config.data_compression }})
     {%- endif %}
     {% if index_config.partition_schema and index_config.partition_column -%}
       on [{{ index_config.partition_schema }}] ({{ "[" + index_config.partition_column + "]" }})

--- a/dbt/include/sqlserver/macros/adapters/indexes.sql
+++ b/dbt/include/sqlserver/macros/adapters/indexes.sql
@@ -27,6 +27,12 @@
     {%- endif %}
     {% if index_config.include_columns -%}
       include ({{ "[" + index_config.include_columns|join("], [") + "]" }})
+    {%- endif %}
+    {% if index_config.data_compression -%}
+      with (data_compression = {{ data_compression }})
+    {%- endif %}
+    {% if index_config.partition_schema and index_config.partition_column -%}
+      on [{{ index_config.partition_schema }}] ({{ "[" + index_config.partition_column + "]" }})
     {%- endif %};
 {%- endmacro %}
 


### PR DESCRIPTION
Implementation of #163

- [x] clustered / nonclustered indexes
- [x] row-store (b-tree) / columnstore indexes
- [x] uniqueness (`UNIQUE`) for row-store indexes (clustered and nonclustered)
- [x] nonclustered row-store index may have included columns: `INCLUDE (col1, col2)`
- [x] data compression: `ROW` / `PAGE` compression for row-store and `COLUMNSTORE` / `COLUMNSTORE_ARCHIVE` for columnstore
- [x] partitioning (partition schema name and partition column)