### PR TITLE
set env vars explicitly to fix circle ci check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,11 +125,14 @@ jobs:
             export AZURE_TENANT_ID="$DBT_AZURE_TENANT"
             cd test/integration
             dbt compile --target azuresql_azauto
-      # - run:
-      #     name: cnxn -- Azure SQL - AZ SP env
-      #     command: |
-      #       cd test/integration
-      #       dbt compile --target azuresql_azenv
+      - run:
+          name: cnxn -- Azure SQL - AZ SP env
+          command: |
+            export AZURE_CLIENT_ID="$DBT_AZURE_SP_NAME"
+            export AZURE_CLIENT_SECRET="$DBT_AZURE_SP_SECRET"
+            export AZURE_TENANT_ID="$DBT_AZURE_TENANT"
+            cd test/integration
+            dbt compile --target azuresql_azenv
 
 workflows:
   main:


### PR DESCRIPTION
I don't have any experience with Circle CI, but the point is that it should have the same env vars set as in the check above.