### PR TITLE
Add possibility to define query hints for models

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,14 +192,21 @@ vars:
   max_batch_size: 200 # Any integer less than  or equal to 2100 will do.
 ```
 
-### Type hints
+### Materialization Query Hints
 
-You are able to provide [T-SQL Query Hints](https://docs.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query?view=sql-server-ver15) for model materializations using a new config parameter `query_hints`.
+You are able to specify [T-SQL Query Hints](https://docs.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query) 
+for table and incremental model materializations using a config parameter `query_hints`.
+For other materialization types the parameter has no effect.
 
-With it, you can for instance overwrite the max degree of parallelism for a particular model:
+For example, you can overwrite the max degree of parallelism for a particular model:
 
 ```
-{{ config(query_hints='MAXDOP 1') }}
+{{ config(query_hints="MAXDOP 1") }}
+```
+
+Multiple query hints can be provided using comma:
+```
+{{ config(query_hints="MAXDOP 1, USE HINT('QUERY_OPTIMIZER_COMPATIBILITY_LEVEL_110')") }}
 ```
 
 ### Hooks

--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ vars:
   max_batch_size: 200 # Any integer less than  or equal to 2100 will do.
 ```
 
+### Type hints
+
+You are able to provide [T-SQL Query Hints](https://docs.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query?view=sql-server-ver15) for model materializations using a new config parameter `query_hints`.
+
+With it, you can for instance overwrite the max degree of parallelism for a particular model:
+
+```
+{{ config(query_hints='MAXDOP 1') }}
+```
+
 ### Hooks
 
 ### Custom schemas

--- a/dbt/include/sqlserver/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/table/create_table_as.sql
@@ -1,5 +1,6 @@
 {% macro sqlserver__create_table_as(temporary, relation, sql) -%}
    {%- set as_columnstore = config.get('as_columnstore', default=true) -%}
+   {%- set query_hints = config.get('query_hints', default=None) -%}
    {% set tmp_relation = relation.incorporate(
    path={"identifier": relation.identifier.replace("#", "") ~ '_temp_view'},
    type='view')-%}
@@ -16,6 +17,7 @@
 
    SELECT * INTO {{ relation }} FROM
     {{ tmp_relation }}
+    {% if query_hints %}OPTION ({{ query_hints }}){% endif -%}
 
    {{ sqlserver__drop_relation_script(tmp_relation) }}
     


### PR DESCRIPTION
**Background:**
In my organization sometimes is useful to specify [T-SQL query hints](https://docs.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query?view=sql-server-ver15) to improve query performance. Unfortunately, as far as I know with the current design of model materialization it is not possible to simply specify hints as part of our models, because later they are first created as views, and we cannot pass anything to `SELECT * INTO ... FROM ...` data loading part.

**New feature:**
In this PR I would like to add a new parameter `query_hints` to model config, which gives the ability to specify query hints according to needs when models are materialized as `table` and `incremental`.

**Usage examples:**
```
{{ config(query_hints="MAXDOP 1") }}
```
Multiple query hints can be provided using commas:
```
{{ config(query_hints="MAXDOP 1, USE HINT('QUERY_OPTIMIZER_COMPATIBILITY_LEVEL_110')") }}
```
I have tested this feature with Azure SQL Database.