### PR TITLE
Add get_true_sql function for sqlserver adapter to allow snapshots to…

### DIFF
--- a/dbt/include/sqlserver/macros/materializations/snapshots/snapshot.sql
+++ b/dbt/include/sqlserver/macros/materializations/snapshots/snapshot.sql
@@ -13,3 +13,7 @@
     {% endcall %}
   {% endfor %}
 {% endmacro %}
+
+{% macro sqlserver__get_true_sql() %}
+  {{ return('1=1') }}
+{% endmacro %}


### PR DESCRIPTION
Snapshots currently break when adding new columns to SQL Server.  A recent update to dbt-core changes the snapshot logic to use an adapter for new columns so that different languages can correctly handle a where clause that is always true.