### PR TITLE
run CI tests on trusted PRs and include secrets

### DIFF
--- a/.github/workflows/integration-tests-azure.yml
+++ b/.github/workflows/integration-tests-azure.yml
@@ -1,43 +1,13 @@
 ---
-name: Integration tests
+name: Integration tests on Azure
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  pull_request_target:
+    types: [labeled]
 
 jobs:
-  integration-tests-sql-server:
-    name: Integration tests on SQL Server
-    strategy:
-      fail-fast: false
-      matrix:
-        python_version: ["3.7", "3.8", "3.9"]
-        profile: ["ci_sql_server", "ci_sql_server_encrypt"]
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ github.repository }}:${{ matrix.python_version }}
-    services:
-      sqlserver:
-        image: mcr.microsoft.com/mssql/server:2019-latest
-        env:
-          ACCEPT_EULA: 'Y'
-          SA_PASSWORD: 5atyaNadella
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install dependencies
-        run: pip install -e . && pip install -r dev_requirements.txt
-
-      - name: Run functional tests
-        run: |
-          RAW_TOXENV="py${{ matrix.python_version }}"
-          TOXENV=$(echo $RAW_TOXENV | sed 's/\.//')
-          tox -e "$TOXENV" -- tests/functional --profile "${{ matrix.profile }}"
-
   integration-tests-azure:
     name: Integration tests on Azure
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/integration-tests-sqlserver.yml
+++ b/.github/workflows/integration-tests-sqlserver.yml
@@ -1,0 +1,37 @@
+---
+name: Integration tests on SQL Server
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  integration-tests-sql-server:
+    name: Integration tests on SQL Server
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.7", "3.8", "3.9"]
+        profile: ["ci_sql_server", "ci_sql_server_encrypt"]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}:${{ matrix.python_version }}
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        env:
+          ACCEPT_EULA: 'Y'
+          SA_PASSWORD: 5atyaNadella
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: pip install -e . && pip install -r dev_requirements.txt
+
+      - name: Run functional tests
+        run: |
+          RAW_TOXENV="py${{ matrix.python_version }}"
+          TOXENV=$(echo $RAW_TOXENV | sed 's/\.//')
+          tox -e "$TOXENV" -- tests/functional --profile "${{ matrix.profile }}"


### PR DESCRIPTION
CI tests were failing on PRs from external contributors because the secrets were not available

this changes that so that the tests without secrets always run and the tests needing secrets are only triggered when you add the label `safe to test`