### PR TITLE
add TrustServerCertificate to Windows login

### DIFF
--- a/dbt/adapters/sqlserver/connections.py
+++ b/dbt/adapters/sqlserver/connections.py
@@ -339,6 +339,7 @@ class SQLServerConnectionManager(SQLConnectionManager):
 
             elif getattr(credentials, "windows_login", False):
                 con_str.append("trusted_connection=yes")
+                con_str.append("TrustServerCertificate=yes")
             elif type_auth == "sql":
                 con_str.append(f"UID={{{credentials.UID}}}")
                 con_str.append(f"PWD={{{credentials.PWD}}}")


### PR DESCRIPTION
`ODBC Driver 18 for SQL Server` gives the following database error when compiling and needs this in the connection string. Tested locally with both Drivers 17 and 18.

Database Error
  ('08001', '[08001] [Microsoft][ODBC Driver 18 for SQL Server]SSL Provider: The certificate chain was issued by an authority that is not trusted.\r\n (-2146893019) (SQLDriverConnect); [08001] [Microsoft][ODBC Driver 18 for SQL Server]Client unable to establish connection (-2146893019); [08001] [Microsoft][ODBC Driver 18 for SQL Server]Invalid connection string attribute (0)')