### PR TITLE
Automatically provision Azure AD users if enabled

### DIFF
--- a/.github/workflows/integration-tests-azure.yml
+++ b/.github/workflows/integration-tests-azure.yml
@@ -69,4 +69,4 @@ jobs:
           DBT_TEST_AAD_PRINCIPAL_1: ${{ secrets.DBT_TEST_AAD_PRINCIPAL_1 }}
           DBT_TEST_AAD_PRINCIPAL_2: ${{ secrets.DBT_TEST_AAD_PRINCIPAL_2 }}
           SQLSERVER_TEST_DRIVER: 'ODBC Driver ${{ matrix.msodbc_version }} for SQL Server'
-        run: pytest tests/functional --profile "${{ matrix.profile }}"
+        run: pytest -ra -v tests/functional --profile "${{ matrix.profile }}"

--- a/.github/workflows/integration-tests-azure.yml
+++ b/.github/workflows/integration-tests-azure.yml
@@ -66,5 +66,7 @@ jobs:
           DBT_TEST_USER_1: DBT_TEST_USER_1
           DBT_TEST_USER_2: DBT_TEST_USER_2
           DBT_TEST_USER_3: DBT_TEST_USER_3
+          DBT_TEST_AAD_PRINCIPAL_1: ${{ secrets.DBT_TEST_AAD_PRINCIPAL_1 }}
+          DBT_TEST_AAD_PRINCIPAL_2: ${{ secrets.DBT_TEST_AAD_PRINCIPAL_2 }}
           SQLSERVER_TEST_DRIVER: 'ODBC Driver ${{ matrix.msodbc_version }} for SQL Server'
         run: pytest tests/functional --profile "${{ matrix.profile }}"

--- a/.github/workflows/integration-tests-sqlserver.yml
+++ b/.github/workflows/integration-tests-sqlserver.yml
@@ -37,7 +37,7 @@ jobs:
         run: pip install -r dev_requirements.txt
 
       - name: Run functional tests
-        run: pytest tests/functional --profile "ci_sql_server"
+        run: pytest -ra -v tests/functional --profile "ci_sql_server"
         env:
           DBT_TEST_USER_1: DBT_TEST_USER_1
           DBT_TEST_USER_2: DBT_TEST_USER_2

--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,12 @@ linecheck: ## Checks for all Python lines 100 characters or more
 .PHONY: unit
 unit: ## Runs unit tests.
 	@\
-	pytest -v tests/unit
+	pytest -ra -v tests/unit
 
 .PHONY: functional
 functional: ## Runs functional tests.
 	@\
-	pytest -v tests/functional
+	pytest -ra -v tests/functional
 
 .PHONY: test
 test: ## Runs unit tests and code checks against staged changes.

--- a/dbt/adapters/sqlserver/sql_server_credentials.py
+++ b/dbt/adapters/sqlserver/sql_server_credentials.py
@@ -21,6 +21,7 @@ class SQLServerCredentials(Credentials):
     encrypt: Optional[bool] = True  # default value in MS ODBC Driver 18 as well
     trust_cert: Optional[bool] = False  # default value in MS ODBC Driver 18 as well
     retries: int = 1
+    auto_provision_aad_principals: Optional[bool] = False
 
     _ALIASES = {
         "user": "UID",
@@ -55,6 +56,8 @@ class SQLServerCredentials(Credentials):
             "authentication",
             "encrypt",
             "trust_cert",
+            "retries",
+            "auto_provision_aad_principals",
         )
 
     @property

--- a/dbt/include/sqlserver/macros/adapters/apply_grants.sql
+++ b/dbt/include/sqlserver/macros/adapters/apply_grants.sql
@@ -9,9 +9,6 @@
 {% endmacro %}
 
 
-
-
-
 {%- macro sqlserver__get_grant_sql(relation, privilege, grantees) -%}
     {%- set grantees_safe = [] -%}
     {%- for grantee in grantees -%}

--- a/dbt/include/sqlserver/macros/adapters/apply_grants.sql
+++ b/dbt/include/sqlserver/macros/adapters/apply_grants.sql
@@ -6,4 +6,21 @@
     where TABLE_CATALOG = '{{ relation.database }}'
       and TABLE_SCHEMA = '{{ relation.schema }}'
       and TABLE_NAME = '{{ relation.identifier }}'
-    {% endmacro %}
+{% endmacro %}
+
+
+{%- macro sqlserver_get_grant_sql(relation, privilege, grantees) -%}
+    {%- set grantees_safe = [] -%}
+    {%- for grantee in grantees -%}
+        {%- set grantee_safe = "[" ~ grantee ~ "]" -%}
+        {%- do grantees_safe.append(grantee_safe) -%}
+
+        {%- if target.auto_provision_aad_principals is not none and target.auto_provision_aad_principals -%}
+            if not exists(select name from sys.database_principals where name = '{{ grantee_safe }}')
+            create user {{ grantee_safe }} from external provider;
+        {%- endif -%}
+
+    {%- endfor -%}
+
+    grant {{ privilege }} on {{ relation }} to {{ grantees_safe | join(', ') }};
+{%- endmacro -%}

--- a/dbt/include/sqlserver/macros/adapters/apply_grants.sql
+++ b/dbt/include/sqlserver/macros/adapters/apply_grants.sql
@@ -9,18 +9,78 @@
 {% endmacro %}
 
 
-{%- macro sqlserver_get_grant_sql(relation, privilege, grantees) -%}
-    {%- set grantees_safe = [] -%}
-    {%- for grantee in grantees -%}
-        {%- set grantee_safe = "[" ~ grantee ~ "]" -%}
-        {%- do grantees_safe.append(grantee_safe) -%}
-
-        {%- if target.auto_provision_aad_principals is not none and target.auto_provision_aad_principals -%}
-            if not exists(select name from sys.database_principals where name = '{{ grantee_safe }}')
-            create user {{ grantee_safe }} from external provider;
+{%- macro sqlserver__get_dcl_statement_list(relation, grant_config, get_dcl_macro) -%}
+    {#
+      -- Unpack grant_config into specific privileges and the set of users who need them granted/revoked.
+      -- Depending on whether this database supports multiple grantees per statement, pass in the list of
+      -- all grantees per privilege, or (if not) template one statement per privilege-grantee pair.
+      -- `get_dcl_macro` will be either `get_grant_sql` or `get_revoke_sql`
+    #}
+    {%- set dcl_statements = [] -%}
+    {%- for privilege, grantees in grant_config.items() %}
+        {%- set grantees_safe = [] -%}
+        {%- for grantee in grantees -%}
+            {#
+                Grantees are wrapped in [] to avoid issues with spaces or other special chars in their names.
+            #}
+            {%- set grantee_safe = "[" ~ grantee ~ "]" -%}
+            {%- do grantees_safe.append(grantee_safe) -%}
+        {%- endfor -%}
+        {%- if support_multiple_grantees_per_dcl_statement() and grantees_safe -%}
+          {%- set dcl = get_dcl_macro(relation, privilege, grantees_safe) -%}
+          {%- do dcl_statements.append(dcl) -%}
+        {%- else -%}
+          {%- for grantee in grantees_safe -%}
+              {% set dcl = get_dcl_macro(relation, privilege, [grantee]) %}
+              {%- do dcl_statements.append(dcl) -%}
+          {% endfor -%}
         {%- endif -%}
-
     {%- endfor -%}
+    {{ return(dcl_statements) }}
+{%- endmacro %}
 
-    grant {{ privilege }} on {{ relation }} to {{ grantees_safe | join(', ') }};
-{%- endmacro -%}
+
+{% macro get_provision_sql(relation, privilege, grantees) %}
+    {% for grantee in grantees %}
+        if not exists(select name from sys.database_principals where name = '{{ grantee }}')
+        create user {{ grantee }} from external provider;
+    {% endfor %}
+{% endmacro %}
+
+
+{% macro sqlserver__apply_grants(relation, grant_config, should_revoke=True) %}
+    {#-- If grant_config is {} or None, this is a no-op --#}
+    {% if grant_config %}
+        {% if should_revoke %}
+            {#-- We think previous grants may have carried over --#}
+            {#-- Show current grants and calculate diffs --#}
+            {% set current_grants_table = run_query(get_show_grant_sql(relation)) %}
+            {% set current_grants_dict = adapter.standardize_grants_dict(current_grants_table) %}
+            {% set needs_granting = diff_of_two_dicts(grant_config, current_grants_dict) %}
+            {% set needs_revoking = diff_of_two_dicts(current_grants_dict, grant_config) %}
+            {% if not (needs_granting or needs_revoking) %}
+                {{ log('On ' ~ relation ~': All grants are in place, no revocation or granting needed.')}}
+            {% endif %}
+        {% else %}
+            {#-- We don't think there's any chance of previous grants having carried over. --#}
+            {#-- Jump straight to granting what the user has configured. --#}
+            {% set needs_revoking = {} %}
+            {% set needs_granting = grant_config %}
+        {% endif %}
+        {% if needs_granting or needs_revoking %}
+            {% set revoke_statement_list = get_dcl_statement_list(relation, needs_revoking, get_revoke_sql) %}
+
+            {% if target.auto_provision_aad_principals is not none and target.auto_provision_aad_principals %}
+                {% set provision_statement_list = get_dcl_statement_list(relation, needs_granting, get_provision_sql) %}
+            {% else %}
+                {% set provision_statement_list = [] %}
+            {% endif %}
+
+            {% set grant_statement_list = get_dcl_statement_list(relation, needs_granting, get_grant_sql) %}
+            {% set dcl_statement_list = revoke_statement_list + provision_statement_list + grant_statement_list %}
+            {% if dcl_statement_list %}
+                {{ call_dcl_statements(dcl_statement_list) }}
+            {% endif %}
+        {% endif %}
+    {% endif %}
+{% endmacro %}

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,6 @@ env_files =
 testpaths =
     tests/unit
     tests/functional
+markers =
+    skip_profile
+    only_with_profile

--- a/tests/functional/adapter/test_provision_users.py
+++ b/tests/functional/adapter/test_provision_users.py
@@ -7,17 +7,21 @@ my_model_sql = """
 """
 
 cleanup_existing_sql = """
-if exists(
-    select *
-    from sys.database_principals
-    where name = '{{ env_var('DBT_TEST_AAD_PRINCIPAL_1') }}')
-drop user {{ env_var('DBT_TEST_AAD_PRINCIPAL_1') }}
+{%- call statement('drop_existing', fetch_result=False) -%}
 
-if exists(
-    select *
-    from sys.database_principals
-    where name = '{{ env_var('DBT_TEST_AAD_PRINCIPAL_2') }}')
-drop user {{ env_var('DBT_TEST_AAD_PRINCIPAL_2') }}
+    if exists(
+        select *
+        from sys.database_principals
+        where name = '{{ env_var('DBT_TEST_AAD_PRINCIPAL_1') }}')
+    drop user {{ env_var('DBT_TEST_AAD_PRINCIPAL_1') }}
+
+    if exists(
+        select *
+        from sys.database_principals
+        where name = '{{ env_var('DBT_TEST_AAD_PRINCIPAL_2') }}')
+    drop user {{ env_var('DBT_TEST_AAD_PRINCIPAL_2') }}
+
+{%- endcall -%}
 """
 
 model_schema_single_user_yml = """

--- a/tests/functional/adapter/test_provision_users.py
+++ b/tests/functional/adapter/test_provision_users.py
@@ -1,0 +1,73 @@
+import pytest
+from dbt.adapters.base import BaseAdapter
+from dbt.tests.util import run_dbt
+
+my_model_sql = """
+  select 1 as fun
+"""
+
+cleanup_existing_sql = """
+if exists(
+    select *
+    from sys.database_principals
+    where name = '{{ env_var('DBT_TEST_AAD_PRINCIPAL_1') }}')
+drop user {{ env_var('DBT_TEST_AAD_PRINCIPAL_1') }}
+
+if exists(
+    select *
+    from sys.database_principals
+    where name = '{{ env_var('DBT_TEST_AAD_PRINCIPAL_2') }}')
+drop user {{ env_var('DBT_TEST_AAD_PRINCIPAL_2') }}
+"""
+
+model_schema_single_user_yml = """
+version: 2
+models:
+  - name: my_model
+    config:
+      grants:
+        select: ["{{ env_var('DBT_TEST_AAD_PRINCIPAL_1') }}"]
+"""
+
+model_schema_multiple_users_yml = """
+version: 2
+models:
+  - name: my_model
+    config:
+      grants:
+        select:
+          - "{{ env_var('DBT_TEST_AAD_PRINCIPAL_1') }}"
+          - "{{ env_var('DBT_TEST_AAD_PRINCIPAL_2') }}"
+"""
+
+
+class BaseTestProvisionAzureSQL:
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "cleanup_existing.sql": cleanup_existing_sql,
+        }
+
+    def test_auto_provision(self, project, adapter: BaseAdapter):
+        adapter.execute_macro("cleanup_existing")
+        run_dbt(["run"])
+
+
+@pytest.mark.only_with_profile("ci_azure_cli", "ci_azure_auto", "ci_azure_environment")
+class TestProvisionSingleUserAzureSQL(BaseTestProvisionAzureSQL):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "schema.yml": model_schema_single_user_yml,
+        }
+
+
+@pytest.mark.only_with_profile("ci_azure_cli", "ci_azure_auto", "ci_azure_environment")
+class TestProvisionMultipleUsersAzureSQL(BaseTestProvisionAzureSQL):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "schema.yml": model_schema_multiple_users_yml,
+        }


### PR DESCRIPTION
This would automatically provision Azure AD users used in grants if they are not created in the database yet. This is using contained database users which would only be possible in Azure SQL and Azure Synapse.