### PR TITLE
Add support for dbt core 1.4

### DIFF
--- a/.github/workflows/integration-tests-azure.yml
+++ b/.github/workflows/integration-tests-azure.yml
@@ -15,7 +15,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.ref_name == 'master' || github.ref_name == 'azure-testing'
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10"]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         profile: ["ci_azure_cli", "ci_azure_auto", "ci_azure_environment", "ci_azure_basic"]
         msodbc_version: ["17", "18"]
       max-parallel: 1

--- a/.github/workflows/integration-tests-sqlserver.yml
+++ b/.github/workflows/integration-tests-sqlserver.yml
@@ -15,7 +15,7 @@ jobs:
     name: Integration tests on SQL Server
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10"]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         msodbc_version: ["17", "18"]
         sqlserver_version: ["2017", "2019", "2022"]
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -12,7 +12,7 @@ jobs:
   publish-docker-client:
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10"]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         docker_target: ["msodbc17", "msodbc18"]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     name: Unit tests
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10"]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 #### Features
 
 * Support for [dbt-core 1.4](https://github.com/dbt-labs/dbt-core/releases/tag/v1.4.1)
+  * [Incremental predicates](https://docs.getdbt.com/docs/build/incremental-models#about-incremental_predicates) are currently not supported in this adapter
+  * Add support for Python 3.11
+  * Replace deprecated exception functions
+  * Consolidate timestamp macros
 
 ### v1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### v1.4.0
+
+#### Features
+
+* Support for [dbt-core 1.4](https://github.com/dbt-labs/dbt-core/releases/tag/v1.4.1)
+
 ### v1.3.0
 
 #### Features

--- a/dbt/adapters/sqlserver/__version__.py
+++ b/dbt/adapters/sqlserver/__version__.py
@@ -1,1 +1,1 @@
-version = "1.3.1"
+version = "1.4.0"

--- a/dbt/adapters/sqlserver/sql_server_connection_manager.py
+++ b/dbt/adapters/sqlserver/sql_server_connection_manager.py
@@ -250,19 +250,19 @@ class SQLServerConnectionManager(SQLConnectionManager):
             except pyodbc.Error:
                 logger.debug("Failed to release connection!")
 
-            raise dbt.exceptions.DatabaseException(str(e).strip()) from e
+            raise dbt.exceptions.DbtDatabaseError(str(e).strip()) from e
 
         except Exception as e:
             logger.debug(f"Error running SQL: {sql}")
             logger.debug("Rolling back transaction.")
             self.release()
-            if isinstance(e, dbt.exceptions.RuntimeException):
+            if isinstance(e, dbt.exceptions.DbtRuntimeError):
                 # during a sql query, an internal to dbt exception was raised.
                 # this sounds a lot like a signal handler and probably has
                 # useful information, so raise it without modification.
                 raise
 
-            raise dbt.exceptions.RuntimeException(e)
+            raise dbt.exceptions.DbtRuntimeError(e)
 
     @classmethod
     def open(cls, connection: Connection) -> Connection:

--- a/dbt/include/sqlserver/macros/adapters/freshness.sql
+++ b/dbt/include/sqlserver/macros/adapters/freshness.sql
@@ -1,3 +1,0 @@
-{% macro sqlserver__current_timestamp() -%}
-  SYSDATETIME()
-{%- endmacro %}

--- a/dbt/include/sqlserver/macros/materializations/models/incremental/merge.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/incremental/merge.sql
@@ -9,7 +9,10 @@
   {{ default__get_merge_sql(target, source, unique_key, dest_columns, predicates) }};
 {% endmacro %}
 
-{% macro sqlserver__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) %}
+{% macro sqlserver__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) %}
+      {% if incremental_predicates %}
+          {{ exceptions.raise_not_implemented('incremental_predicates are not implemented in dbt-sqlserver') }}
+      {% endif %}
 
       {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
 

--- a/dbt/include/sqlserver/macros/materializations/snapshots/strategies.sql
+++ b/dbt/include/sqlserver/macros/materializations/snapshots/strategies.sql
@@ -3,8 +3,3 @@
         coalesce(cast({{ arg }} as varchar(max)), '') {% if not loop.last %} + '|' + {% endif %}
     {% endfor %}), 2)
 {% endmacro %}
-
-{% macro sqlserver__snapshot_string_as_time(timestamp) -%}
-    {%- set result = "CONVERT(DATETIME2, '" ~ timestamp ~ "')" -%}
-    {{ return(result) }}
-{%- endmacro %}

--- a/dbt/include/sqlserver/macros/utils/timestamps.sql
+++ b/dbt/include/sqlserver/macros/utils/timestamps.sql
@@ -1,0 +1,8 @@
+{% macro sqlserver__current_timestamp() -%}
+  SYSDATETIME()
+{%- endmacro %}
+
+{% macro sqlserver__snapshot_string_as_time(timestamp) -%}
+    {%- set result = "CONVERT(DATETIME2, '" ~ timestamp ~ "')" -%}
+    {{ return(result) }}
+{%- endmacro %}

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,5 +3,6 @@ twine==4.0.2
 wheel==0.38.4
 pre-commit==2.20.0
 pytest-dotenv==0.5.2
+pytz==2023.3
 dbt-tests-adapter==1.4.1
 -e .

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,5 +3,5 @@ twine==4.0.2
 wheel==0.38.4
 pre-commit==2.20.0
 pytest-dotenv==0.5.2
-dbt-tests-adapter==1.3.1
+dbt-tests-adapter==1.4.1
 -e .

--- a/setup.py
+++ b/setup.py
@@ -67,8 +67,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~=1.4.0",
-        "pyodbc>=4.0.32,!=4.0.34",
-        "azure-identity>=1.10.0",
+        "pyodbc~=4.0.35,!=4.0.36,!=4.0.37",
+        "azure-identity>=1.12.0",
     ],
     cmdclass={
         "verify": VerifyVersionCommand,
@@ -83,5 +83,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.install import install
 
 package_name = "dbt-sqlserver"
 authors_list = ["Mikael Ene", "Anders Swanson", "Sam Debruyn", "Cor Zuurmond"]
-dbt_version = "1.3"
+dbt_version = "1.4"
 description = """A Microsoft SQL Server adapter plugin for dbt"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
@@ -66,7 +66,7 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-core>=1.3.0",
+        "dbt-core~=1.4.0",
         "pyodbc>=4.0.32,!=4.0.34",
         "azure-identity>=1.10.0",
     ],

--- a/tests/functional/adapter/test_timestamps.py
+++ b/tests/functional/adapter/test_timestamps.py
@@ -1,0 +1,18 @@
+import pytest
+from dbt.tests.adapter.utils.test_timestamps import BaseCurrentTimestamps
+
+
+class TestCurrentTimestampSQLServer(BaseCurrentTimestamps):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "get_current_timestamp.sql": 'select {{ current_timestamp() }} as "current_timestamp"'
+        }
+
+    @pytest.fixture(scope="class")
+    def expected_schema(self):
+        return {"current_timestamp": "datetime2"}
+
+    @pytest.fixture(scope="class")
+    def expected_sql(self):
+        return '''select SYSDATETIME() as "current_timestamp"'''


### PR DESCRIPTION
Resolves https://github.com/dbt-msft/dbt-sqlserver/issues/333.

Checklist:
- [x]  support Python 3.11 (only if your adapter's dependencies allow)
- [x]  Consolidate timestamp functions & macros
- [x]  Replace deprecated exception functions
- [ ]  Add support for more tests

Works with my dbt projects using both Azure SQL Database and Microsoft SQL Server 2017.

This PR requires changes around `incremental_predicates`, but as I do not use incremental materialisations much, I do not have time to test everything properly and write tests, so for now I have marked this feature as not implemented. The changes required do not look huge, so I may try to add them later.

