### PR TITLE
fix: adds pyodbc output converter for DATETIMEOFFSET data types

### DIFF
--- a/dbt/adapters/sqlserver/sql_server_connection_manager.py
+++ b/dbt/adapters/sqlserver/sql_server_connection_manager.py
@@ -1,6 +1,6 @@
+import datetime as dt
 import struct
 import time
-import datetime as dt
 from contextlib import contextmanager
 from itertools import chain, repeat
 from typing import Any, Callable, Dict, Mapping, Optional, Tuple
@@ -237,16 +237,16 @@ def bool_to_connection_string_arg(key: str, value: bool) -> str:
 def byte_array_to_datetime(value: bytes) -> dt.datetime:
     """
     Converts a DATETIMEOFFSET byte array to a timezone-aware datetime object
-    
+
     Parameters
     ----------
     value : buffer
         A binary value conforming to SQL_SS_TIMESTAMPOFFSET_STRUCT
-    
+
     Returns
     -------
     out : datetime
-    
+
     Source
     ------
     SQL_SS_TIMESTAMPOFFSET datatype and SQL_SS_TIMESTAMPOFFSET_STRUCT layout:
@@ -263,9 +263,10 @@ def byte_array_to_datetime(value: bytes) -> dt.datetime:
         hour=tup[3],
         minute=tup[4],
         second=tup[5],
-        microsecond=tup[6] // 1000, # https://bugs.python.org/issue15443
+        microsecond=tup[6] // 1000,  # https://bugs.python.org/issue15443
         tzinfo=dt.timezone(dt.timedelta(hours=tup[7], minutes=tup[8])),
     )
+
 
 class SQLServerConnectionManager(SQLConnectionManager):
     TYPE = "sqlserver"
@@ -431,7 +432,7 @@ class SQLServerConnectionManager(SQLConnectionManager):
             # convert DATETIMEOFFSET binary structures to datetime ojbects
             # https://github.com/mkleehammer/pyodbc/issues/134#issuecomment-281739794
             connection.handle.add_output_converter(-155, byte_array_to_datetime)
-            
+
             logger.debug(
                 "SQL status: {} in {:0.2f} seconds".format(
                     self.get_response(cursor), (time.time() - pre)

--- a/dbt/adapters/sqlserver/sql_server_connection_manager.py
+++ b/dbt/adapters/sqlserver/sql_server_connection_manager.py
@@ -263,7 +263,7 @@ def byte_array_to_datetime(value: bytes) -> dt.datetime:
         hour=tup[3],
         minute=tup[4],
         second=tup[5],
-        microsecond=tup[6],
+        microsecond=tup[6] // 1000, # https://bugs.python.org/issue15443
         tzinfo=dt.timezone(dt.timedelta(hours=tup[7], minutes=tup[8])),
     )
 

--- a/tests/unit/adapters/sqlserver/test_sql_server_connection_manager.py
+++ b/tests/unit/adapters/sqlserver/test_sql_server_connection_manager.py
@@ -117,7 +117,7 @@ def test_bool_to_connection_string_arg(key: str, value: bool, expected: str) -> 
                 microsecond=123456700 // 1000,  # 10⁻⁶ second
                 tzinfo=dt.timezone(dt.timedelta(hours=-2, minutes=-30)),
             ),
-            "2021-12-17 17:52:18.123456-02:30",
+            "2022-12-17 17:52:18.123456-02:30",
         )
     ],
 )

--- a/tests/unit/adapters/sqlserver/test_sql_server_connection_manager.py
+++ b/tests/unit/adapters/sqlserver/test_sql_server_connection_manager.py
@@ -86,21 +86,21 @@ def test_bool_to_connection_string_arg(key: str, value: bool, expected: str) -> 
             bytes(
                 [
                     0xE6,
-                    0x07,  #  2022       year            unsigned short
+                    0x07,  # 2022       year            unsigned short
                     0x0C,
-                    0x00,  #  12         month           unsigned short
+                    0x00,  # 12         month           unsigned short
                     0x11,
-                    0x00,  #  17         day             unsigned short
+                    0x00,  # 17         day             unsigned short
                     0x11,
-                    0x00,  #  17         hour            unsigned short
+                    0x00,  # 17         hour            unsigned short
                     0x34,
-                    0x00,  #  52         minute          unsigned short
+                    0x00,  # 52         minute          unsigned short
                     0x12,
-                    0x00,  #  18         second          unsigned short
+                    0x00,  # 18         second          unsigned short
                     0xBC,
                     0xCC,
                     0x5B,
-                    0x07,  #  123456700  10⁻⁷ second     unsigned long
+                    0x07,  # 123456700  10⁻⁷ second     unsigned long
                     0xFE,
                     0xFF,  # -2          offset hour     signed short
                     0xE2,

--- a/tests/unit/adapters/sqlserver/test_sql_server_connection_manager.py
+++ b/tests/unit/adapters/sqlserver/test_sql_server_connection_manager.py
@@ -80,7 +80,7 @@ def test_bool_to_connection_string_arg(key: str, value: bool, expected: str) -> 
     assert bool_to_connection_string_arg(key, value) == expected
 
 @pytest.mark.parametrize(
-    "value, expected", [
+    "value, expected_datetime, expected_str", [
         (
             bytes([
                 0xE5, 0x07,             # year: 2022
@@ -89,17 +89,19 @@ def test_bool_to_connection_string_arg(key: str, value: bool, expected: str) -> 
                 0x16, 0x00,             # hour: 22
                 0x16, 0x00,             # minute: 22
                 0x12, 0x00,             # second: 18
-                0x40, 0xE2, 0x01, 0x00, # microsecond: 123456
+                0x15, 0xCD, 0x5B, 0x07, # microsecond: 123456789
                 0x02, 0x00, 0x1E, 0x00  # tzinfo: +02:30
             ]),
+            dt.datetime(2022, 12, 17, 22, 22, 18, 123456, dt.timezone(dt.timedelta(hours=2, minutes=30))),
             "2021-12-17 22:22:18.123456+02:30"
         )
     ]
 )
-def test_byte_array_to_datetime(value: bytes, expected: dt.datetime) -> None:
+def test_byte_array_to_datetime(value: bytes, expected_datetime: dt.datetime, expected_str: str) -> None:
     """
     Assert SQL_SS_TIMESTAMPOFFSET_STRUCT bytes convert to string in an expected isoformat
     https://docs.python.org/3/library/datetime.html#datetime.datetime.__str__
     https://learn.microsoft.com/sql/relational-databases/native-client-odbc-date-time/data-type-support-for-odbc-date-and-time-improvements#sql_ss_timestampoffset_struct
     """
-    assert str(byte_array_to_datetime(value)) == expected
+    assert byte_array_to_datetime(value) == expected_datetime
+    assert str(byte_array_to_datetime(value)) == expected_str

--- a/tests/unit/adapters/sqlserver/test_sql_server_connection_manager.py
+++ b/tests/unit/adapters/sqlserver/test_sql_server_connection_manager.py
@@ -92,17 +92,14 @@ def test_bool_to_connection_string_arg(key: str, value: bool, expected: str) -> 
                 0x40, 0xE2, 0x01, 0x00, # microsecond: 123456
                 0x02, 0x00, 0x1E, 0x00  # tzinfo: +02:30
             ]),
-            dt.datetime(
-                2021, 12, 17,
-                22, 22,
-                18, 123456,
-                dt.timezone(dt.timedelta(hours=2, minutes=30))
-            )
+            "2021-12-17 22:22:18.123456+02:30"
         )
     ]
 )
 def test_byte_array_to_datetime(value: bytes, expected: dt.datetime) -> None:
     """
-    
+    Assert SQL_SS_TIMESTAMPOFFSET_STRUCT bytes convert to string in an expected isoformat
+    https://docs.python.org/3/library/datetime.html#datetime.datetime.__str__
+    https://learn.microsoft.com/sql/relational-databases/native-client-odbc-date-time/data-type-support-for-odbc-date-and-time-improvements#sql_ss_timestampoffset_struct
     """
-    assert byte_array_to_datetime(value) == expected
+    assert str(byte_array_to_datetime(value)) == expected

--- a/tests/unit/adapters/sqlserver/test_sql_server_connection_manager.py
+++ b/tests/unit/adapters/sqlserver/test_sql_server_connection_manager.py
@@ -85,15 +85,15 @@ def test_bool_to_connection_string_arg(key: str, value: bool, expected: str) -> 
         (
             bytes(
                 [
-                    0xE5,
+                    0xE6,
                     0x07,  #  2022       year            unsigned short
                     0x0C,
                     0x00,  #  12         month           unsigned short
                     0x11,
                     0x00,  #  17         day             unsigned short
-                    0x16,
+                    0x11,
                     0x00,  #  17         hour            unsigned short
-                    0x16,
+                    0x34,
                     0x00,  #  52         minute          unsigned short
                     0x12,
                     0x00,  #  18         second          unsigned short


### PR DESCRIPTION
Fixes #253, supercedes #254

pyodbc is unlikley to include a handler for DATETIMEOFFSET data types - see [mkleehammer/pyodbc#134](https://github.com/mkleehammer/pyodbc/issues/134).

So, this PR adds support to convert these datatypes to standard `datetime` objects based on public MS documentation.

This should allow [freshness](https://docs.getdbt.com/reference/resource-properties/freshness) functonality to use DATETIMEOFFSET columns without needing to use CAST/CONVERT in [loaded_at_field](https://docs.getdbt.com/reference/resource-properties/freshness#loaded_at_field) resource properties.

Tests are against `str(value: datetime)` default string format, since this asserts compatibility with:
- [innoverio.vscode-dbt-power-user](https://github.com/innoverio/vscode-dbt-power-user)'s query preview
- exotic use of the [run_query](https://docs.getdbt.com/reference/dbt-jinja-functions/run_query) jinja macro