### PR TITLE
avoid publishing docker from other branches than master

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -7,12 +7,6 @@ on:  # yamllint disable-line rule:truthy
       - '.github/workflows/publish-docker.yml'
     branches:
       - 'master'
-  pull_request:
-    paths:
-      - 'devops/**'
-      - '.github/workflows/publish-docker.yml'
-    branches:
-      - 'master'
 
 jobs:
   publish-docker-client:


### PR DESCRIPTION
this would allow anyone to publish images on the same tags, disrupting the workflows on master