### PR TITLE
bugfix: Install a correct version of `dbt-core` that is compatible with the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### v1.3.2
+
+#### Fixes
+
+* Install a correct version of `dbt-core` that is compatible with the library 
+
+
 ### v1.3.0
 
 #### Features

--- a/dbt/adapters/sqlserver/__version__.py
+++ b/dbt/adapters/sqlserver/__version__.py
@@ -1,1 +1,1 @@
-version = "1.3.1"
+version = "1.3.2"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,5 +3,5 @@ twine==4.0.2
 wheel==0.38.4
 pre-commit==2.20.0
 pytest-dotenv==0.5.2
-dbt-tests-adapter==1.3.1
+dbt-tests-adapter~=1.3.4
 -e .

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-core>=1.3.0",
+        "dbt-core~=1.3.4",
         "pyodbc>=4.0.32,!=4.0.34",
         "azure-identity>=1.10.0",
     ],


### PR DESCRIPTION
This is a bugfix 1.3.2 release, it resolves #348.

As we already have an ongoing v1.4 release on master, this PR requires a v1.3 branch to be created from the v.1.3.1 tag, which I do not think I can do myself. @dataders @sdebruyn can you help with this?
