### PR TITLE
Add missing quotes on clustered columnstore index name

### DIFF
--- a/dbt/include/sqlserver/macros/adapters/indexes.sql
+++ b/dbt/include/sqlserver/macros/adapters/indexes.sql
@@ -9,8 +9,8 @@
         WHERE name = '{{cci_name}}'
         AND object_id=object_id('{{relation_name}}')
     )
-  DROP index {{full_relation}}.{{cci_name}}
-  CREATE CLUSTERED COLUMNSTORE INDEX {{cci_name}}
+  DROP index {{full_relation}}."{{cci_name}}"
+  CREATE CLUSTERED COLUMNSTORE INDEX "{{cci_name}}"
     ON {{full_relation}}
 {% endmacro %}
 


### PR DESCRIPTION
This is my first attempt at contributing to an open source project so let me know if I missed anything.

Resolve database error "Incorrect syntax near '\\'" when using a schema called "domain\user". Raised as issue #409 