### PR TITLE
Fix concat macro when fields list is of length 1.

### DIFF
--- a/dbt/include/sqlserver/macros/utils/concat.sql
+++ b/dbt/include/sqlserver/macros/utils/concat.sql
@@ -1,3 +1,7 @@
 {% macro sqlserver__concat(fields) -%}
-    concat({{ fields|join(', ') }})
+    {%- if fields|length == 1 -%}
+        {{ fields[0] }}
+    {%- else -%}
+        concat({{ fields|join(', ') }})
+    {%- endif -%}
 {%- endmacro %}

--- a/dbt/include/sqlserver/macros/utils/concat.sql
+++ b/dbt/include/sqlserver/macros/utils/concat.sql
@@ -1,7 +1,3 @@
 {% macro sqlserver__concat(fields) -%}
-    {%- if fields|length == 1 -%}
-        {{ fields[0] }}
-    {%- else -%}
-        concat({{ fields|join(', ') }})
-    {%- endif -%}
+    concat('', {{ fields|join(', ') }})
 {%- endmacro %}


### PR DESCRIPTION
This pull request fixes the issue described [here](https://github.com/dbt-labs/dbt-utils/issues/827).

Should this macro handle the case where `fields|length == 0`, or is that case handled upstream?