### PR TITLE
Merge patch changes & fix Dockerfile issue

### DIFF
--- a/.github/workflows/integration-tests-azure.yml
+++ b/.github/workflows/integration-tests-azure.yml
@@ -68,8 +68,6 @@ jobs:
           DBT_TEST_USER_1: DBT_TEST_USER_1
           DBT_TEST_USER_2: DBT_TEST_USER_2
           DBT_TEST_USER_3: DBT_TEST_USER_3
-          DBT_TEST_AAD_PRINCIPAL_1: ${{ secrets.DBT_TEST_AAD_PRINCIPAL_1 }}
-          DBT_TEST_AAD_PRINCIPAL_2: ${{ secrets.DBT_TEST_AAD_PRINCIPAL_2 }}
           SQLSERVER_TEST_DRIVER: 'ODBC Driver ${{ matrix.msodbc_version }} for SQL Server'
         run: pytest --ignore=tests/functional/adapter/test_provision_users.py -ra -v tests/functional --profile "${{ matrix.profile }}"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: mixed-line-ending
       - id: check-docstring-first
   - repo: 'https://github.com/adrienverge/yamllint'
-    rev: v1.31.0
+    rev: v1.32.0
     hooks:
       - id: yamllint
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### v1.4.3
+
+Another minor release to follow up on the 1.4 releases.
+
+Replacing the usage of the `dm_sql_referencing_entities` stored procedure with a query to `sys.sql_expression_dependencies` for better compatibility with child adapters.
+
+### v1.4.2
+
+Minor release to follow up on 1.4.1 and 1.4.0.
+
+Adding `nolock` to information_schema and sys tables/views can be overriden with the dispatched `information_schema_hints` macro. This is required for adapters inheriting from this one.
+
 ### v1.4.1
 
 This is a minor release following up on 1.4.0 with fixes for long outstanding issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,12 @@
 # Development of the adapter
 
-Python 3.10 is used for developing the adapter. To get started, bootstrap your environment as follows:
+## Dependencies
 
-Create a virtual environment, [pyenv](https://github.com/pyenv/pyenv) is used in the example:
+A recent version of [Docker](https://docs.docker.com/get-docker/).
+
+Python 3.10
+
+Create a virtual environment to properly isolate your Python dependencies. Here is an example of how to do so using the [pyenv](https://github.com/pyenv/pyenv) CLI:
 
 ```shell
 pyenv install 3.10.7
@@ -22,22 +26,21 @@ After running `make dev`, pre-commit will automatically validate your commits an
 
 ## Testing
 
-The functional tests require a running SQL Server instance. You can easily spin up a local instance with the following command:
-
-```shell
-make server
-```
-
-This will use Docker Compose to spin up a local instance of SQL Server. Docker Compose is now bundled with Docker, so make sure to [install the latest version of Docker](https://docs.docker.com/get-docker/).
-
-Next, tell our tests how they should connect to the local instance by creating a file called `test.env` in the root of the project.
-You can use the provided `test.env.sample` as a base and if you started the server with `make server`, then this matches the instance running on your local machine.
+The functional tests require a running SQL Server instance. We'll spin one up using Docker Compose. First, copy the example `.env.test.sample` to create a new file `.env.test`, which contains the environment variables that will be read by Docker Compose:
 
 ```shell
 cp test.env.sample test.env
 ```
 
-You can tweak the contents of this file to test against a different database.
+If desired, you can tweak the contents of `test.env` to test against a different database.
+
+Now, you can easily spin up a local SQL Server instance:
+
+```shell
+make server
+```
+
+This will use Docker Compose to fetch the image and run the container. 
 
 Note that we need 3 users to be able to run tests related to the grants.
 The 3 users are defined by the following environment variables containing their usernames.

--- a/dbt/include/sqlserver/macros/adapters/apply_grants.sql
+++ b/dbt/include/sqlserver/macros/adapters/apply_grants.sql
@@ -2,7 +2,7 @@
     select
         GRANTEE as grantee,
         PRIVILEGE_TYPE as privilege_type
-    from INFORMATION_SCHEMA.TABLE_PRIVILEGES with (nolock)
+    from INFORMATION_SCHEMA.TABLE_PRIVILEGES {{ information_schema_hints() }}
     where TABLE_CATALOG = '{{ relation.database }}'
       and TABLE_SCHEMA = '{{ relation.schema }}'
       and TABLE_NAME = '{{ relation.identifier }}'

--- a/dbt/include/sqlserver/macros/adapters/columns.sql
+++ b/dbt/include/sqlserver/macros/adapters/columns.sql
@@ -9,8 +9,8 @@
             c.max_length as character_maximum_length,
             c.precision as numeric_precision,
             c.scale as numeric_scale
-        from [{{ 'tempdb' if '#' in relation.identifier else relation.database }}].sys.columns c with (nolock)
-        inner join sys.types t with (nolock)
+        from [{{ 'tempdb' if '#' in relation.identifier else relation.database }}].sys.columns c {{ information_schema_hints() }}
+        inner join sys.types t {{ information_schema_hints() }}
         on c.user_type_id = t.user_type_id
         where c.object_id = object_id('{{ 'tempdb..' ~ relation.include(database=false, schema=false) if '#' in relation.identifier else relation }}')
     )

--- a/dbt/include/sqlserver/macros/adapters/indexes.sql
+++ b/dbt/include/sqlserver/macros/adapters/indexes.sql
@@ -5,7 +5,7 @@
   use [{{ relation.database }}];
   if EXISTS (
         SELECT *
-        FROM sys.indexes with (nolock)
+        FROM sys.indexes {{ information_schema_hints() }}
         WHERE name = '{{cci_name}}'
         AND object_id=object_id('{{relation_name}}')
     )
@@ -33,8 +33,8 @@
 declare @drop_xml_indexes nvarchar(max);
 select @drop_xml_indexes = (
     select 'IF INDEXPROPERTY(' + CONVERT(VARCHAR(MAX), sys.tables.[object_id]) + ', ''' + sys.indexes.[name] + ''', ''IndexId'') IS NOT NULL DROP INDEX [' + sys.indexes.[name] + '] ON ' + '[' + SCHEMA_NAME(sys.tables.[schema_id]) + '].[' + OBJECT_NAME(sys.tables.[object_id]) + ']; '
-	from sys.indexes with (nolock)
-    inner join sys.tables with (nolock)
+	from sys.indexes {{ information_schema_hints() }}
+    inner join sys.tables {{ information_schema_hints() }}
     on sys.indexes.object_id = sys.tables.object_id
     where sys.indexes.[name] is not null
       and sys.indexes.type_desc = 'XML'
@@ -54,8 +54,8 @@ select @drop_xml_indexes = (
 declare @drop_spatial_indexes nvarchar(max);
 select @drop_spatial_indexes = (
     select 'IF INDEXPROPERTY(' + CONVERT(VARCHAR(MAX), sys.tables.[object_id]) + ', ''' + sys.indexes.[name] + ''', ''IndexId'') IS NOT NULL DROP INDEX [' + sys.indexes.[name] + '] ON ' + '[' + SCHEMA_NAME(sys.tables.[schema_id]) + '].[' + OBJECT_NAME(sys.tables.[object_id]) + ']; '
-    from sys.indexes with (nolock)
-    inner join sys.tables with (nolock)
+    from sys.indexes {{ information_schema_hints() }}
+    inner join sys.tables {{ information_schema_hints() }}
     on sys.indexes.object_id = sys.tables.object_id
     where sys.indexes.[name] is not null
       and sys.indexes.type_desc = 'Spatial'
@@ -119,8 +119,8 @@ select @drop_pk_constraints = (
 declare @drop_remaining_indexes_last nvarchar(max);
 select @drop_remaining_indexes_last = (
     select 'IF INDEXPROPERTY(' + CONVERT(VARCHAR(MAX), sys.tables.[object_id]) + ', ''' + sys.indexes.[name] + ''', ''IndexId'') IS NOT NULL DROP INDEX [' + sys.indexes.[name] + '] ON ' + '[' + SCHEMA_NAME(sys.tables.[schema_id]) + '].[' + OBJECT_NAME(sys.tables.[object_id]) + ']; '
-    from sys.indexes with (nolock)
-    inner join sys.tables with (nolock)
+    from sys.indexes {{ information_schema_hints() }}
+    inner join sys.tables {{ information_schema_hints() }}
     on sys.indexes.object_id = sys.tables.object_id
     where sys.indexes.[name] is not null
       and sys.tables.[name] = '{{ this.table }}'
@@ -137,7 +137,7 @@ select @drop_remaining_indexes_last = (
 {% set idx_name = "clustered_" + local_md5(columns | join("_")) %}
 
 if not exists(select *
-                from sys.indexes with (nolock)
+                from sys.indexes {{ information_schema_hints() }}
                 where name = '{{ idx_name }}'
                 and object_id = OBJECT_ID('{{ this }}')
 )
@@ -170,7 +170,7 @@ end
 {% endif %}
 
 if not exists(select *
-                from sys.indexes with (nolock)
+                from sys.indexes {{ information_schema_hints() }}
                 where name = '{{ idx_name }}'
                 and object_id = OBJECT_ID('{{ this }}')
 )

--- a/dbt/include/sqlserver/macros/adapters/metadata.sql
+++ b/dbt/include/sqlserver/macros/adapters/metadata.sql
@@ -1,3 +1,9 @@
+{% macro information_schema_hints() %}
+    {{ return(adapter.dispatch('information_schema_hints')()) }}
+{% endmacro %}
+
+{% macro default__information_schema_hints() %}{% endmacro %}
+{% macro sqlserver__information_schema_hints() %}with (nolock){% endmacro %}
 
 {% macro sqlserver__get_catalog(information_schemas, schemas) -%}
 
@@ -9,7 +15,7 @@
             name as principal_name,
             principal_id as principal_id
         from
-            sys.database_principals with (nolock)
+            sys.database_principals {{ information_schema_hints() }}
     ),
 
     schemas as (
@@ -18,7 +24,7 @@
             schema_id as schema_id,
             principal_id as principal_id
         from
-            sys.schemas with (nolock)
+            sys.schemas {{ information_schema_hints() }}
     ),
 
     tables as (
@@ -28,7 +34,7 @@
             principal_id as principal_id,
             'BASE TABLE' as table_type
         from
-            sys.tables with (nolock)
+            sys.tables {{ information_schema_hints() }}
     ),
 
     tables_with_metadata as (
@@ -49,7 +55,7 @@
             principal_id as principal_id,
             'VIEW' as table_type
         from
-            sys.views with (nolock)
+            sys.views {{ information_schema_hints() }}
     ),
 
     views_with_metadata as (
@@ -92,7 +98,7 @@
             column_name,
             ordinal_position as column_index,
             data_type as column_type
-        from INFORMATION_SCHEMA.COLUMNS with (nolock)
+        from INFORMATION_SCHEMA.COLUMNS {{ information_schema_hints() }}
 
     )
 
@@ -129,7 +135,7 @@
   {% call statement('list_schemas', fetch_result=True, auto_begin=False) -%}
     USE {{ database }};
     select  name as [schema]
-    from sys.schemas with (nolock)
+    from sys.schemas {{ information_schema_hints() }}
   {% endcall %}
   {{ return(load_result('list_schemas').table) }}
 {% endmacro %}
@@ -153,7 +159,7 @@
            else table_type
       end as table_type
 
-    from [{{ schema_relation.database }}].INFORMATION_SCHEMA.TABLES with (nolock)
+    from [{{ schema_relation.database }}].INFORMATION_SCHEMA.TABLES {{ information_schema_hints() }}
     where table_schema = '{{ schema_relation.schema }}'
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}

--- a/dbt/include/sqlserver/macros/adapters/relation.sql
+++ b/dbt/include/sqlserver/macros/adapters/relation.sql
@@ -15,8 +15,19 @@
 {% macro sqlserver__drop_relation_script(relation) -%}
     {% call statement('find_references', fetch_result=true) %}
         USE [{{ relation.database }}];
-        SELECT referencing_schema_name, referencing_entity_name
-        FROM sys.dm_sql_referencing_entities ('{{ relation.include(database=false) }}', 'object')
+        select
+            sch.name as schema_name,
+            obj.name as view_name
+        from sys.sql_expression_dependencies refs
+        inner join sys.objects obj
+        on refs.referencing_id = obj.object_id
+        inner join sys.schemas sch
+        on obj.schema_id = sch.schema_id
+        where refs.referenced_database_name = '{{ relation.database }}'
+        and refs.referenced_schema_name = '{{ relation.schema }}'
+        and refs.referenced_entity_name = '{{ relation.identifier }}'
+        and refs.referencing_class = 1
+        and obj.type = 'V'
     {% endcall %}
     {% set references = load_result('find_references')['data'] %}
     {% for reference in references -%}
@@ -45,7 +56,7 @@
     EXEC sp_rename '{{ from_relation.schema }}.{{ from_relation.identifier }}', '{{ to_relation.identifier }}'
     IF EXISTS(
     SELECT *
-    FROM sys.indexes with (nolock)
+    FROM sys.indexes {{ information_schema_hints() }}
     WHERE name='{{ from_relation.schema }}_{{ from_relation.identifier }}_cci' and object_id = OBJECT_ID('{{ from_relation.schema }}.{{ to_relation.identifier }}'))
     EXEC sp_rename N'{{ from_relation.schema }}.{{ to_relation.identifier }}.{{ from_relation.schema }}_{{ from_relation.identifier }}_cci', N'{{ from_relation.schema }}_{{ to_relation.identifier }}_cci', N'INDEX'
   {%- endcall %}

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-pytest==7.1.3
+pytest==7.3.1
 twine==4.0.2
 wheel==0.40.0
 pre-commit==2.21.0;python_version<"3.8"
@@ -6,5 +6,5 @@ pre-commit==3.3.2;python_version>="3.8"
 pytest-dotenv==0.5.2
 dbt-tests-adapter~=1.5.1rc1
 flaky==3.7.0
-pytest-xdist==3.3.0
+pytest-xdist==3.3.1
 -e .

--- a/devops/server.Dockerfile
+++ b/devops/server.Dockerfile
@@ -3,8 +3,12 @@ FROM mcr.microsoft.com/mssql/server:${MSSQL_VERSION}-latest
 
 ENV COLLATION="SQL_Latin1_General_CP1_CI_AS"
 
+USER root
+
 RUN mkdir -p /opt/init_scripts
 WORKDIR /opt/init_scripts
 COPY scripts/* /opt/init_scripts/
+
+USER mssql
 
 ENTRYPOINT /bin/bash ./entrypoint.sh

--- a/setup.py
+++ b/setup.py
@@ -85,4 +85,10 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
+    project_urls={
+        "Setup & configuration": "https://docs.getdbt.com/reference/warehouse-profiles/mssql-profile",  # noqa: E501
+        "Documentation & usage": "https://docs.getdbt.com/reference/resource-configs/mssql-configs",  # noqa: E501
+        "Changelog": "https://github.com/dbt-msft/dbt-sqlserver/blob/master/CHANGELOG.md",  # noqa: E501
+        "Issue Tracker": "https://github.com/dbt-msft/dbt-sqlserver/issues",  # noqa: E501
+    },
 )


### PR DESCRIPTION
- Merges upstream patch changes 1.4.2 and 1.4.3
- Gives Dockerfile root permissions for creating `/opt/init_scripts` before reverting to the container's default user `msssql`.
- Updates docs accordingly with some minor rearrangements.

Any idea why this error in the Dockerfile went unnoticed until now? I'm on WSL/Ubuntu 22.04/Docker latest