### PR TITLE
[V1.3.latest] Added ability OPTION clause when creating a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### v1.3.2
 
+#### Features
+- Allow setting table `OPTIONS` using `config`
+
 #### Fixes
 
 * Install a correct version of `dbt-core` that is compatible with the library 

--- a/dbt/include/sqlserver/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/table/create_table_as.sql
@@ -1,5 +1,6 @@
 {% macro sqlserver__create_table_as(temporary, relation, sql) -%}
    {%- set as_columnstore = config.get('as_columnstore', default=true) -%}
+   {%- set option_clause  = config.get('option_clause') -%}
    {% set tmp_relation = relation.incorporate(
    path={"identifier": relation.identifier.replace("#", "") ~ '_temp_view'},
    type='view')-%}
@@ -16,6 +17,9 @@
 
    SELECT * INTO {{ relation }} FROM
     {{ tmp_relation }}
+   {% if option_clause  %}
+      OPTION( {{ option_clause }} )
+   {% endif %}
 
    {{ sqlserver__drop_relation_script(tmp_relation) }}
 

--- a/dbt/include/sqlserver/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/table/create_table_as.sql
@@ -1,6 +1,7 @@
 {% macro sqlserver__create_table_as(temporary, relation, sql) -%}
    {%- set as_columnstore = config.get('as_columnstore', default=true) -%}
    {%- set option_clause  = config.get('option_clause') -%}
+   {%- set sql_header = config.get('sql_header') -%}
    {% set tmp_relation = relation.incorporate(
    path={"identifier": relation.identifier.replace("#", "") ~ '_temp_view'},
    type='view')-%}
@@ -14,6 +15,10 @@
    EXEC('create view {{ tmp_relation.include(database=False) }} as
     {{ temp_view_sql }}
     ');
+    
+   {% if sql_header %}
+      {{ sql_header }} 
+   {% endif %}
 
    SELECT * INTO {{ relation }} FROM
     {{ tmp_relation }}


### PR DESCRIPTION
In some cases, users need to use the [`OPTION()`](https://learn.microsoft.com/en-us/sql/t-sql/queries/option-clause-transact-sql?view=sql-server-ver16) clause in their dbt models that appears in SQL Server. The problem is that dbt does not provide this capability. A good reproducing example is the recursive code below, fetching data from the database. 
test table `calendar` containing a wide range of dates
![image](https://github.com/dbt-msft/dbt-sqlserver/assets/114922270/adbdb44c-9fe5-4857-8a07-83c9b40d7cc9)

```sql
WITH cte
  AS (SELECT [date]
        FROM calendar
       WHERE DATE = '2020-01-01'
      UNION ALL
      SELECT DATEADD(day, 1, [date]) as [date]
        FROM cte
       WHERE DATEADD(day, 1, [date]) 
       < '2021-01-01'
    --    < '2020-02-28'
       )
SELECT *
  FROM cte
  OPTION (MAXRECURSION 0);
```
In the case of the condition `< '2021-01-01'`, the recursion exceeds 100. Therefore, if you do not use the `OPTION` clause `(MAXRECURSION 0)`, in this scenario, the recursion will stop at 100, not retrieving all the data in the query. However, in the case of table creation, an error will occur. `MAXRECURSION`is just one example; there are many more options.

The use of the option clause in dbt. Below, I'm providing code that demonstrates the use of the option parameter in dbt.

```sql
{{
    config({
        "materialized": 'table',
        "option_clause": "MAXRECURSION 0"
    })

}}
WITH cte
  AS (SELECT [date]
        FROM calendar
       WHERE DATE = '2020-01-01'
      UNION ALL
      SELECT DATEADD(day, 1, [date]) as [date]
        FROM cte
       WHERE DATEADD(day, 1, [date]) 
    < '2021-01-01'
    -- < '2020-02-28'
       )
SELECT *
  FROM cte
```

