### PR TITLE
Feature/support python3.12

### DIFF
--- a/.github/workflows/integration-tests-sqlserver.yml
+++ b/.github/workflows/integration-tests-sqlserver.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         msodbc_version: ["17", "18"]
         sqlserver_version: ["2017", "2019", "2022"]
         collation: ["SQL_Latin1_General_CP1_CS_AS", "SQL_Latin1_General_CP1_CI_AS"]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
     name: Unit tests
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/dbt/adapters/sqlserver/__version__.py
+++ b/dbt/adapters/sqlserver/__version__.py
@@ -1,1 +1,1 @@
-version = "1.7.2rc1"
+version = "1.7.2rc2"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,4 +7,5 @@ dbt-tests-adapter==1.7.2
 dbt-fabric==1.7.2
 flaky==3.7.0
 pytest-xdist==3.5.0
+setuptools==69.0.3
 -e .

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         "dbt-fabric~=1.7.2",
         "pyodbc>=4.0.35,<5.1.0",
         "azure-identity>=1.12.0",
+        "setup-tools~=63.0.3",
     ],
     cmdclass={
         "verify": VerifyVersionCommand,
@@ -85,6 +86,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     project_urls={
         "Setup & configuration": "https://docs.getdbt.com/reference/warehouse-profiles/mssql-profile",  # noqa: E501


### PR DESCRIPTION
Feature: Support python 3.12

- Update CI testing for python 3.12
- Update setup.py for python 3.12 (note added package dependency setuptools; [refer to pep 632](https://peps.python.org/pep-0632/) )