### PR TITLE
bugfix table materizaltion constraints name

### DIFF
--- a/dbt/include/sqlserver/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/table/create_table_as.sql
@@ -16,7 +16,7 @@ SQL Server doesnt support this, so we use the 'SELECT * INTO XYZ FROM ABC' synta
     {% if contract_config.enforced %}
 
         CREATE TABLE [{{relation.database}}].[{{relation.schema}}].[{{relation.identifier}}]
-        {{ fabric__table_columns_and_constraints(relation) }}
+        {{ fabric__build_columns_constraints(relation) }}
         {{ get_assert_columns_equivalent(sql)  }}
 
         {% set listColumns %}


### PR DESCRIPTION
Overwritten table adapter materizalization name from Fabric change. It's related with @ #494 