### PR TITLE
Update drop all schemas to target only schemas of a table in a given index

### DIFF
--- a/dbt/include/sqlserver/macros/adapter/indexes.sql
+++ b/dbt/include/sqlserver/macros/adapter/indexes.sql
@@ -108,6 +108,7 @@
         inner join sys.tables {{ information_schema_hints() }}
         on sys.indexes.object_id = sys.tables.object_id
         where sys.indexes.[name] is not null
+        and SCHEMA_NAME(sys.tables.schema_id) = '{{ this.schema }}'
         and sys.tables.[name] = '{{ this.table }}'
         for xml path('')
     ); exec sp_executesql @drop_remaining_indexes_last;

--- a/dbt/include/sqlserver/macros/materializations/tests.sql
+++ b/dbt/include/sqlserver/macros/materializations/tests.sql
@@ -1,0 +1,46 @@
+{% macro sqlserver__get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}
+
+  -- Create target schema if it does not
+  USE [{{ target.database }}];
+  IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{{ target.schema }}')
+  BEGIN
+    EXEC('CREATE SCHEMA [{{ target.schema }}]')
+  END
+
+  {% set with_statement_pattern = 'with .+ as\s*\(' %}
+  {% set re = modules.re %}
+  {% set is_match = re.search(with_statement_pattern, main_sql, re.IGNORECASE) %}
+
+  {% if is_match %}
+    {% set testview %}
+      [{{ target.schema }}.testview_{{ range(1300, 19000) | random }}]
+    {% endset %}
+
+    {% set sql = main_sql.replace("'", "''")%}
+    EXEC('create view {{testview}} as {{ sql }};')
+    select
+      {{ "top (" ~ limit ~ ')' if limit != none }}
+      {{ fail_calc }} as failures,
+      case when {{ fail_calc }} {{ warn_if }}
+        then 'true' else 'false' end as should_warn,
+      case when {{ fail_calc }} {{ error_if }}
+        then 'true' else 'false' end as should_error
+    from (
+      select * from {{testview}}
+    ) dbt_internal_test;
+
+    EXEC('drop view {{testview}};')
+
+  {% else -%}
+    select
+      {{ "top (" ~ limit ~ ')' if limit != none }}
+      {{ fail_calc }} as failures,
+      case when {{ fail_calc }} {{ warn_if }}
+        then 'true' else 'false' end as should_warn,
+      case when {{ fail_calc }} {{ error_if }}
+        then 'true' else 'false' end as should_error
+    from (
+      {{ main_sql }}
+    ) dbt_internal_test
+  {%- endif -%}
+{%- endmacro %}

--- a/tests/functional/adapter/mssql/test_test_with.py
+++ b/tests/functional/adapter/mssql/test_test_with.py
@@ -1,0 +1,113 @@
+import pytest
+from dbt.tests.util import run_dbt
+
+sample_model = """
+SELECT
+    1 as ID,
+    'a' as data
+
+UNION ALL
+
+SELECT
+    2 as ID,
+    'b' as data
+
+UNION ALL
+
+SELECT
+    2 as ID,
+    'c' as data
+"""
+
+pass_model_yml = """
+version: 2
+models:
+- name: sample_model
+  data_tests:
+  - with_statement_pass:
+      field: ID
+"""
+
+fail_model_yml = """
+version: 2
+models:
+- name: sample_model
+  data_tests:
+  - with_statement_fail:
+      field: ID
+"""
+
+with_test_fail_sql = """
+{% test with_statement_fail(model, field) %}
+
+with test_sample AS (
+    SELECT {{ field }} FROM {{ model }}
+    GROUP BY {{ field }}
+    HAVING COUNT(*) > 1
+)
+SELECT * FROM test_sample
+
+{% endtest %}
+"""
+
+with_test_pass_sql = """
+{% test with_statement_pass(model, field) %}
+
+with test_sample AS (
+    SELECT {{ field }} FROM {{ model }}
+    GROUP BY {{ field }}
+    HAVING COUNT(*) > 2
+)
+SELECT * FROM test_sample
+
+{% endtest %}
+"""
+
+
+class BaseSQLTestWith:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "config-version": 2,
+            "macro-paths": ["macros"],
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "with_statement_pass.sql": with_test_pass_sql,
+            "with_statement_fail.sql": with_test_fail_sql,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "sample_model.sql": sample_model,
+            "schema.yml": pass_model_yml,
+        }
+
+
+class TestSQLTestWithPass(BaseSQLTestWith):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "sample_model.sql": sample_model,
+            "schema.yml": pass_model_yml,
+        }
+
+    def test_sql_test_contains_with(self, project):
+        run_dbt(["run"])
+        run_dbt(["test"])
+
+
+class TestSQLTestWithFail(BaseSQLTestWith):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "sample_model.sql": sample_model,
+            "schema.yml": fail_model_yml,
+        }
+
+    def test_sql_test_contains_with(self, project):
+        run_dbt(["run"])
+        run_dbt(["test"], expect_pass=False)


### PR DESCRIPTION
Updated version of this PR to drop schemas on a target table in a target schema.

Current behaviour drops the indexes on all tables that match the target, regardless of schema.

https://github.com/dbt-msft/dbt-sqlserver/pull/439

Closes issue https://github.com/dbt-msft/dbt-sqlserver/issues/519