### PR TITLE
Fix incorrect syntax near keyword 'as' in catalog creation

### DIFF
--- a/dbt/include/sqlserver/macros/adapter/catalog.sql
+++ b/dbt/include/sqlserver/macros/adapter/catalog.sql
@@ -96,7 +96,7 @@
                 c.column_id as column_index,
                 t.name as column_type
             from sys.columns as c {{ information_schema_hints() }}
-            left join sys.types {{ information_schema_hints() }} as t on c.system_type_id = t.system_type_id
+            left join sys.types as t {{ information_schema_hints() }} on c.system_type_id = t.system_type_id
         )
 
         select


### PR DESCRIPTION
Resolves incorrect syntax near keyword error that I reported as an issue earlier as issue https://github.com/dbt-msft/dbt-sqlserver/issues/556