### PR TITLE
fix to make drop_schema_name usable and test pass

### DIFF
--- a/dbt/include/sqlserver/macros/adapters/schema.sql
+++ b/dbt/include/sqlserver/macros/adapters/schema.sql
@@ -37,7 +37,7 @@
 {% endmacro %}
 
 {% macro sqlserver__drop_schema_named(schema_name) %}
-  {% set schema_relation = api.Relation.create(schema=schema_name) %}
+  {% set schema_relation = api.Relation.create(schema=schema_name, database=target.database) %}
   {{ adapter.drop_schema(schema_relation) }}
 {% endmacro %}
 

--- a/tests/functional/adapter/dbt/test_relations.py
+++ b/tests/functional/adapter/dbt/test_relations.py
@@ -1,5 +1,3 @@
-import pytest
-
 from dbt.tests.adapter.relations.test_changing_relation_type import BaseChangeRelationTypeValidator
 from dbt.tests.adapter.relations.test_dropping_schema_named import BaseDropSchemaNamed
 
@@ -8,10 +6,5 @@ class TestChangeRelationTypeValidator(BaseChangeRelationTypeValidator):
     pass
 
 
-@pytest.mark.xfail(reason="""
-                  Test fails as its not passing Use[] properly.
-                  `Use[None]` is called, should be `User[TestDB]`
-                  Unclear why the macro doens't pass it properly.
-                  """)
 class TestDropSchemaNamed(BaseDropSchemaNamed):
     pass


### PR DESCRIPTION
Use default target database when passed only the schema name so subsequent macros can use it.

This will enable this test and the functionality. All tests passing.