### PR TITLE
Update unit_tests.sql to replace square brackets with double quotes

### DIFF
--- a/dbt/include/sqlserver/macros/materializations/unit_tests.sql
+++ b/dbt/include/sqlserver/macros/materializations/unit_tests.sql
@@ -3,17 +3,17 @@
 USE [{{ target.database }}];
 IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{{ target.schema }}')
 BEGIN
-EXEC('CREATE SCHEMA [{{ target.schema }}]')
+EXEC('CREATE SCHEMA "{{ target.schema }}"')
 END
 
 {% set test_view %}
-    [{{ target.schema }}.testview_{{ range(1300, 19000) | random }}]
+    "{{ target.schema }}"."testview_{{ range(1300, 19000) | random }}"
 {% endset %}
 {% set test_sql = main_sql.replace("'", "''")%}
 EXEC('create view {{test_view}} as {{ test_sql }};')
 
 {% set expected_view %}
-    [{{ target.schema }}.expectedview_{{ range(1300, 19000) | random }}]
+    "{{ target.schema }}"."expectedview_{{ range(1300, 19000) | random }}"
 {% endset %}
 {% set expected_sql = expected_fixture_sql.replace("'", "''")%}
 EXEC('create view {{expected_view}} as {{ expected_sql }};')


### PR DESCRIPTION
Replace square brackets with double quotes and insert "." between schema and view in setting of test_view and expected_view.

Result was [dbo.testview_123] will now be "dbo"."testview_123" Result was [dbo.expectedview_123] will now be "dbo"."expectedview_123"