### PR TITLE
Change dbt upperbound to 2.0

### DIFF
--- a/dbt/adapters/sqlserver/__version__.py
+++ b/dbt/adapters/sqlserver/__version__.py
@@ -1,1 +1,1 @@
-version = "1.8.7"
+version = "1.9.4"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 
-dbt-tests-adapter>=1.8.0, <1.9.0
+dbt-tests-adapter>=1.8.0, <2.0.0
 
 ruff
 black==24.8.0

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-fabric>=1.8.0,<2.0.0",
+        "dbt-fabric==1.9.4",
         "dbt-core>=1.8.0,<2.0.0",
         "dbt-common>=1.0,<2.0",
         "dbt-adapters>=1.1.1,<2.0",

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,8 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-fabric>=1.8.0,<1.9.0",
-        "dbt-core>=1.8.0,<1.9.0",
+        "dbt-fabric>=1.8.0,<2.0.0",
+        "dbt-core>=1.8.0,<2.0.0",
         "dbt-common>=1.0,<2.0",
         "dbt-adapters>=1.1.1,<2.0",
     ],


### PR DESCRIPTION
As of dbt 1.8, adapter versions no longer need to match the dbt-core version. By the rules of semantic versioning, dbt-core should not introduce breaking changes in a minor or patch, so this should be safe until dbt-core 2.0.

https://docs.getdbt.com/docs/dbt-versions/core#how-we-version-adapter-plugins