### PR TITLE
sqlserver_column.py: Handle string dtype of nvarchar

### DIFF
--- a/dbt/adapters/sqlserver/sqlserver_column.py
+++ b/dbt/adapters/sqlserver/sqlserver_column.py
@@ -20,3 +20,31 @@ class SQLServerColumn(FabricColumn):
             "serial8",
             "int",
         ]
+
+    def is_string(self) -> bool:
+        return self.dtype.lower() in [
+            "text",
+            "character varying",
+            "character",
+            "varchar",
+            "nvarchar",
+        ]
+
+    def string_size(self) -> int:
+        if not self.is_string():
+            raise DbtRuntimeError("Called string_size() on non-string field!")
+
+        if self.dtype == "text" or self.char_size is None:
+            # char_size should never be None. Handle it reasonably just in case
+            return 256
+        elif self.dtype.lower() == "nvarchar":
+            # char_size is doubled for nvarchar
+            return int(self.char_size // 2)
+        else:
+            return int(self.char_size)
+
+    def string_type(self, size: int) -> str:
+        if self.dtype:
+            return f"{self.dtype}({size if size > 0 else '8000'})"
+        else:
+            return f"varchar({size if size > 0 else '8000'})"

--- a/dbt/adapters/sqlserver/sqlserver_column.py
+++ b/dbt/adapters/sqlserver/sqlserver_column.py
@@ -1,4 +1,5 @@
 from dbt.adapters.fabric import FabricColumn
+from dbt_common.exceptions import DbtRuntimeError
 
 
 class SQLServerColumn(FabricColumn):


### PR DESCRIPTION
nvarchar is not considered a string in the base adapter, nor in the fabric adapter. This leads to issues when dealing with nvarchar columns, such as in https://github.com/dbt-msft/dbt-sqlserver-utils/blob/master/macros/sql/union.sql

In this commit we add nvarchar to the list of string dtypes, return the correct string_size for nvarchar (which is doubled by default), and use the correct dtype in string_type.

I believe this mishandling of nvarchar is the root cause of #446 

I ran into this issue when unioning multiple relations which used nvarchar. The generated code had no string length specified for the nvarchar fields, which resulted in the default string length of 30 being used.