### PR TITLE
sqlserver_column.py: Handle string dtype of nvarchar

### DIFF
--- a/dbt/adapters/sqlserver/sqlserver_column.py
+++ b/dbt/adapters/sqlserver/sqlserver_column.py
@@ -20,3 +20,31 @@ class SQLServerColumn(FabricColumn):
             "serial8",
             "int",
         ]
+
+    def is_string(self) -> bool:
+        return self.dtype.lower() in [
+            "text",
+            "character varying",
+            "character",
+            "varchar",
+            "nvarchar",
+        ]
+
+    def string_size(self) -> int:
+        if not self.is_string():
+            raise DbtRuntimeError("Called string_size() on non-string field!")
+
+        if self.dtype == "text" or self.char_size is None:
+            # char_size should never be None. Handle it reasonably just in case
+            return 256
+        elif self.dtype.lower() == "nvarchar":
+            # char_size is doubled for nvarchar
+            return int(self.char_size // 2)
+        else:
+            return int(self.char_size)
+
+    def string_type(self, size: int) -> str:
+        if self.dtype:
+            return f"{self.dtype}({size if size > 0 else '8000'})"
+        else:
+            return f"varchar({size if size > 0 else '8000'})"

--- a/dbt/adapters/sqlserver/sqlserver_column.py
+++ b/dbt/adapters/sqlserver/sqlserver_column.py
@@ -1,4 +1,5 @@
 from dbt.adapters.fabric import FabricColumn
+from dbt_common.exceptions import DbtRuntimeError
 
 
 class SQLServerColumn(FabricColumn):

--- a/dbt/include/sqlserver/macros/adapter/columns.sql
+++ b/dbt/include/sqlserver/macros/adapter/columns.sql
@@ -48,3 +48,36 @@
     {% do run_query(rename_column) %}
 
 {% endmacro %}
+
+{% macro sqlserver__get_columns_in_relation(relation) -%}
+    {% set query_label = apply_label() %}
+    {% call statement('get_columns_in_relation', fetch_result=True) %}
+        {{ get_use_database_sql(relation.database) }}
+        with mapping as (
+            select
+                row_number() over (partition by object_name(c.object_id) order by c.column_id) as ordinal_position,
+                c.name collate database_default as column_name,
+                t.name as data_type,
+                c.max_length as character_maximum_length,
+                c.precision as numeric_precision,
+                c.scale as numeric_scale
+            from sys.columns c {{ information_schema_hints() }}
+            inner join sys.types t {{ information_schema_hints() }}
+            on c.user_type_id = t.user_type_id
+            where c.object_id = object_id('{{ 'tempdb..' ~ relation.include(database=false, schema=false) if '#' in relation.identifier else relation }}')
+        )
+
+        select
+            column_name,
+            data_type,
+            character_maximum_length,
+            numeric_precision,
+            numeric_scale
+        from mapping
+        order by ordinal_position
+        {{ query_label }}
+
+    {% endcall %}
+    {% set table = load_result('get_columns_in_relation').table %}
+    {{ return(sql_convert_columns_in_relation(table)) }}
+{% endmacro %}


### PR DESCRIPTION
nvarchar is not considered a string in the base adapter, nor in the fabric adapter. This leads to issues when dealing with nvarchar columns, such as in https://github.com/dbt-msft/dbt-sqlserver-utils/blob/master/macros/sql/union.sql

In this commit we add nvarchar to the list of string dtypes, return the correct string_size for nvarchar (which is doubled by default), and use the correct dtype in string_type.

I believe this mishandling of nvarchar is the root cause of https://github.com/dbt-msft/dbt-sqlserver/issues/446

I ran into this issue when unioning multiple relations which used nvarchar. The generated code had no string length specified for the nvarchar fields, which resulted in the default string length of 30 being used.

I'm not sure if how I handle string_type is best, as it is a class method in the base class, but I think we want it to be instance specific as that is how the dtypes are handled.

Additionally, I'm not sure why char_size is twice the string length for nvarchar but I noticed it in my testing which is why I halve it in string_size(). I do understand that nvarchar uses twice the bytes as varchar, so suspect it is related, but I don't know if we would want to fix char_size to be the actual number of characters or just fix it in string_size.