### PR TITLE
Create packages.yml

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,9 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1
+  - package: dbt-labs/codegen
+    version: 0.12.1
+  - package: calogica/dbt_expectations
+    version: 0.10.3
+  - package: elementary-data/elementary
+    version: 0.14.1


### PR DESCRIPTION
The packages.yml file in dbt can declare external dbt projects (called packages) that your project depends on, allowing you to reuse models, macros, and tests from other developers. This file is placed at the root level of your dbt project, alongside your dbt_project.yml file