### PR TITLE
fix: Use uv to create and activate a workspace .venv to avoid permissions errors

### DIFF
--- a/.devcontainer/setup_env.sh
+++ b/.devcontainer/setup_env.sh
@@ -1,14 +1,14 @@
+set -euo pipefail
+
 cp test.env.sample test.env
 
 docker compose build
 docker compose up -d
 
-# Install uv in system Python
+# Install uv in the container user environment.
 pip install uv
 
-# Use uv to install dependencies in system Python
-uv pip install --system -r dev_requirements.txt
-
-# Install pre-commit hooks
-uv pip install --system pre-commit
+# Use a workspace-local virtualenv so package installs do not fail on user permissions.
+uv pip install -r dev_requirements.txt
+source .venv/bin/activate
 pre-commit install


### PR DESCRIPTION
Final fix to devcontainer behavior, some devcontainers make permissions strictier.

This also allows non-devcontainer easier setup.