### PR TITLE
fix: devcontainer post-start sequentially 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
         "ghcr.io/devcontainers/features/docker-in-docker:2.17.0": {}
     },
     "forwardPorts": [1433],
-    "postStartCommand": "/bin/bash ./.devcontainer/setup_odbc.sh & /bin/bash ./.devcontainer/setup_env.sh",
+    "postStartCommand": "/bin/bash ./.devcontainer/setup_odbc.sh && /bin/bash ./.devcontainer/setup_env.sh",
     "containerEnv": {
         "SQLSERVER_TEST_DRIVER": "ODBC Driver 18 for SQL Server",
         "SQLSERVER_TEST_HOST": "127.0.0.1",


### PR DESCRIPTION
Because uv runs too fast and stops the background odbc install after ending... thanks uv