### PR TITLE
Bump v1.9.1 release and keeps pyodbc temporary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+### v1.9.1
+
+- Removes the dependency on `dbt-fabric`.
+
+### v1.9.0
+
+- Update to support `dbt-core` 1.9.
+- Remove Python 3.8 from official support.
+
+### v1.8.7
+
+- Bump version for release 1.8.7.
+
+### v1.8.6
+
+- Bump version for release 1.8.6.
+
+### v1.8.5
+
+- Fix broken imports from Fabric.
+
 ### v1.8.4
 
 - Minor fix to tests with CTEs which do not start on first line. https://github.com/dbt-msft/dbt-sqlserver/issues/560

--- a/dbt/adapters/sqlserver/__version__.py
+++ b/dbt/adapters/sqlserver/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.1rc1"
+version = "1.9.1"

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         "dbt-core>=1.9.0,<2.0",
         "dbt-common>=1.0,<2.0",
         "dbt-adapters>=1.11.0,<2.0",
+        "pyodbc>=5.2.0",
     ],
     cmdclass={
         "verify": VerifyVersionCommand,


### PR DESCRIPTION
To avoid unwanted and non-announced dependency removals o some cases we needed to keep pyodcb dependency temporary.