### PR TITLE
chore(dependabot): switch Dependabot to weekly and separate security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,46 @@
----
 version: 2
+
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: daily
-  - package-ecosystem: github-actions
+      interval: "weekly"
+    groups:
+      pip-updates:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+      pip-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
-  - package-ecosystem: docker
-    directory: "/"
+      interval: "weekly"
+    groups:
+      github-actions-updates:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/devops"
     schedule:
-      interval: daily
+      interval: "weekly"
+    groups:
+      docker-updates:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+      docker-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"

--- a/.github/workflows/integration-tests-sqlserver.yml
+++ b/.github/workflows/integration-tests-sqlserver.yml
@@ -36,6 +36,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   integration-tests-sql-server:
     name: Regular
+    if: github.actor != 'dependabot[bot]'
     strategy:
       matrix:
         python_version: ["3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
chore(dependabot): switch Dependabot to weekly and separate security update groups, avoid integration tests from dependabot