### PR TITLE
Update adapter to dbt 1.10.

### DIFF
--- a/dbt/adapters/sqlserver/__version__.py
+++ b/dbt/adapters/sqlserver/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.1"
+version = "1.10.0"

--- a/dbt/adapters/sqlserver/sqlserver_relation.py
+++ b/dbt/adapters/sqlserver/sqlserver_relation.py
@@ -58,19 +58,19 @@ class SQLServerRelation(BaseRelation):
         if event_time_filter.start and event_time_filter.end:
             filter = (
                 f"{event_time_filter.field_name} >="
-                f" cast('{event_time_filter.start}' as datetimeoffset)"
+                f" cast('{event_time_filter.start}' as datetime2)"
                 f" and {event_time_filter.field_name} <"
-                f" cast('{event_time_filter.end}' as datetimeoffset)"
+                f" cast('{event_time_filter.end}' as datetime2)"
             )
         elif event_time_filter.start:
             filter = (
                 f"{event_time_filter.field_name} >="
-                f" cast('{event_time_filter.start}' as datetimeoffset)"
+                f" cast('{event_time_filter.start}' as datetime2)"
             )
         elif event_time_filter.end:
             filter = (
                 f"{event_time_filter.field_name} <"
-                f" cast('{event_time_filter.end}' as datetimeoffset)"
+                f" cast('{event_time_filter.end}' as datetime2)"
             )
 
         return filter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "dbt-core>=1.9.0,<2.0",
-    "dbt-common>=1.0,<2.0",
-    "dbt-adapters>=1.11.0,<2.0",
+    "dbt-core>=1.10.0,<1.11.0",
+    "dbt-common>=1.22.0,<2.0",
+    "dbt-adapters>=1.15.2,<2.0",
 ]
 dynamic = ["version"]
 
@@ -43,7 +43,7 @@ pyodbc = [
 
 [dependency-groups]
 dev = [
-    "dbt-tests-adapter>=1.9.0,<2.0",
+    "dbt-tests-adapter>=1.15.0,<2.0",
     "azure-identity>=1.12.0",
     "build",
     "bumpversion",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "build",
     "bumpversion",
     "flaky",
-    "freezegun==1.4.0",
+    "freezegun>=1.5.0,<2.0",
     "ipdb",
     "mypy==1.11.2",
     "pre-commit",

--- a/tests/functional/adapter/dbt/test_sample_mode.py
+++ b/tests/functional/adapter/dbt/test_sample_mode.py
@@ -1,0 +1,43 @@
+import os
+from unittest import mock
+
+import freezegun
+import pytest
+
+from dbt.tests.adapter.sample_mode.test_sample_mode import BaseSampleModeTest
+from dbt.tests.util import run_dbt
+
+# BaseSampleModeTest.test_sample_mode uses @freezegun.freeze_time("2025-01-03T02:03:0Z").
+# Align static dates so the "1 day" sample window
+# [2025-01-02 02:03:00, 2025-01-03 02:03:00) selects exactly two rows.
+_input_model_sql = """
+{{ config(materialized='table', event_time='event_time') }}
+select 1 as id, cast('2025-01-01 02:03:00' as datetime2) as event_time
+UNION ALL
+select 2 as id, cast('2025-01-02 14:03:00' as datetime2) as event_time
+UNION ALL
+select 3 as id, cast('2025-01-03 02:02:59' as datetime2) as event_time
+"""
+
+
+class TestSQLServerSampleMode(BaseSampleModeTest):
+    @pytest.fixture(scope="class")
+    def input_model_sql(self) -> str:
+        return _input_model_sql
+
+    @mock.patch.dict(os.environ, {"DBT_EXPERIMENTAL_SAMPLE_MODE": "True"})
+    @freezegun.freeze_time("2025-01-03T02:03:0Z")
+    def test_sample_mode(self, project) -> None:
+        _ = run_dbt(["run"])
+        self.assert_row_count(
+            project=project,
+            relation_name="model_that_samples_input_sql",
+            expected_row_count=3,
+        )
+
+        _ = run_dbt(["run", "--sample=1 day"])
+        self.assert_row_count(
+            project=project,
+            relation_name="model_that_samples_input_sql",
+            expected_row_count=2,
+        )


### PR DESCRIPTION
- Bump package and dbt-core constraints to the 1.10 line
- Align dbt-common/dbt-adapters/dbt-tests-adapter floors with dbt-core 1.10's own pins
- Switch the event_time_filter cast from datetimeoffset to datetime2 (the literal dbt emits is not a valid datetimeoffset on SQL Server)
- Add the BaseSampleModeTest functional test. 

That should be everything we need to bring us up to 1.10 functionality, the iceberg stuff is not for us.