### PR TITLE
Fix CTE detection with comments (#621)

### DIFF
--- a/dbt/include/sqlserver/macros/adapters/columns.sql
+++ b/dbt/include/sqlserver/macros/adapters/columns.sql
@@ -1,5 +1,6 @@
 {% macro sqlserver__get_empty_subquery_sql(select_sql, select_sql_header=none) %}
-    {% if select_sql.strip().lower().startswith('with') %}
+    {%- set select_sql_stripped = modules.re.sub('(?s)/\\*.*?\\*/|--[^\n]*\n', '', select_sql) -%}
+    {% if select_sql_stripped.strip().lower().startswith('with') %}
         {{ select_sql }}
     {% else -%}
         select * from (

--- a/tests/functional/adapter/mssql/test_leading_comments.py
+++ b/tests/functional/adapter/mssql/test_leading_comments.py
@@ -1,0 +1,63 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+model_with_line_comment_sql = """
+-- This is a comment before the WITH clause
+WITH input as (SELECT 1 as id)
+SELECT * FROM input
+"""
+
+model_with_block_comment_sql = """
+/* This is a block comment before the WITH clause */
+WITH input as (SELECT 1 as id)
+SELECT * FROM input
+"""
+
+model_without_cte_sql = """
+-- This is a comment before a non-CTE query
+SELECT 1 as id
+"""
+
+model_yml = """
+version: 2
+models:
+  - name: model_with_line_comment
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: int
+  - name: model_with_block_comment
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: int
+  - name: model_without_cte
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: int
+"""
+
+
+class TestLeadingComments:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_with_line_comment.sql": model_with_line_comment_sql,
+            "model_with_block_comment.sql": model_with_block_comment_sql,
+            "model_without_cte.sql": model_without_cte_sql,
+            "schema.yml": model_yml,
+        }
+
+    def test_comments_before_cte(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 3
+        for result in results:
+            assert result.status == "success", f"{result.node.name} failed"


### PR DESCRIPTION
The CTE short-circuit only fired when select_sql literally began with `with`, so a model with a leading -- or /* */ comment had its CTE wrapped in a subquery and failed with `Incorrect syntax near the keyword 'WITH'`. Strip line and block comments before the startswith check; the original select_sql is still what gets emitted.
Fixes #621 