### PR TITLE
Fix reserved-keyword quoting in table-create DROP VIEW (#619).

### DIFF
--- a/dbt/include/sqlserver/macros/relations/table/create.sql
+++ b/dbt/include/sqlserver/macros/relations/table/create.sql
@@ -33,7 +33,7 @@
     EXEC('{{- escape_single_quotes(query) -}}')
 
     {# For some reason drop_relation is not firing. This solves the issue for now. #}
-    EXEC('DROP VIEW IF EXISTS {{tmp_relation.schema}}.{{tmp_relation.identifier}}')
+    EXEC('DROP VIEW IF EXISTS {{ tmp_relation.include(database=False) }}')
 
 
 

--- a/tests/functional/adapter/mssql/test_reserved_keywords_schema.py
+++ b/tests/functional/adapter/mssql/test_reserved_keywords_schema.py
@@ -1,0 +1,55 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+model_sql = """
+{{ config(materialized="table") }}
+select 1 as id
+"""
+
+
+class TestReservedKeywordsSchema:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model.sql": model_sql}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "test_reserved_keywords_schema",
+            "quoting": {
+                "database": True,
+                "schema": True,
+                "identifier": True,
+            },
+            "models": {
+                "test_reserved_keywords_schema": {
+                    "schema": "group",
+                }
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "generate_schema_name.sql": """
+{% macro generate_schema_name(custom_schema_name, node) -%}
+    {%- if custom_schema_name -%}
+        {{ custom_schema_name | trim }}
+    {%- else -%}
+        {{ target.schema }}
+    {%- endif -%}
+{%- endmacro %}
+"""
+        }
+
+    @pytest.fixture(autouse=True, scope="class")
+    def cleanup_schema(self, project):
+        yield
+        project.run_sql("DROP TABLE IF EXISTS [group].[model]")
+        project.run_sql("DROP SCHEMA IF EXISTS [group]")
+
+    def test_reserved_schema(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"


### PR DESCRIPTION
The inline EXEC('DROP VIEW IF EXISTS ...') in relations/table/create.sql interpolated tmp_relation.schema and tmp_relation.identifier as raw strings.
Switch to the BaseRelation renderer (include(database=False)) so the project's quoting config is respected.
Fixes #619