### PR TITLE
Add TABLOCK hint to contract-enforced INSERT INTO (#640).

### DIFF
--- a/dbt/include/sqlserver/macros/relations/table/create.sql
+++ b/dbt/include/sqlserver/macros/relations/table/create.sql
@@ -22,7 +22,7 @@
                     {{ "["~column~"]" }}{{ ", " if not loop.last }}
                 {% endfor %}
             {%endset%}
-            INSERT INTO {{relation}} ({{listColumns}})
+            INSERT INTO {{relation}} WITH (TABLOCK) ({{listColumns}})
             SELECT {{listColumns}} FROM {{tmp_relation}} {{ query_label }}
 
         {% else %}

--- a/tests/functional/adapter/dbt/test_constraints.py
+++ b/tests/functional/adapter/dbt/test_constraints.py
@@ -472,7 +472,7 @@ class BaseConstraintsRuntimeDdlEnforcement:
     @pytest.fixture(scope="class")
     def expected_sql(self):
         return """
-        EXEC(' create view <model_identifier> as -- depends_on: <foreign_key_model_identifier> select ''blue'' as color, 1 as id, ''2019-01-01'' as date_day; ') EXEC(' CREATE TABLE <model_identifier> ( id int not null , color varchar(100), date_day varchar(100) ) INSERT INTO <model_identifier> ( [id], [color], [date_day] ) SELECT [id], [color], [date_day] FROM <model_identifier>  ') EXEC('DROP VIEW IF EXISTS <model_identifier>
+        EXEC(' create view <model_identifier> as -- depends_on: <foreign_key_model_identifier> select ''blue'' as color, 1 as id, ''2019-01-01'' as date_day; ') EXEC(' CREATE TABLE <model_identifier> ( id int not null , color varchar(100), date_day varchar(100) ) INSERT INTO <model_identifier> WITH (TABLOCK) ( [id], [color], [date_day] ) SELECT [id], [color], [date_day] FROM <model_identifier>  ') EXEC('DROP VIEW IF EXISTS <model_identifier>
         """
 
     # EXEC('DROP view IF EXISTS <model_identifier>
@@ -592,7 +592,7 @@ class BaseModelConstraintsRuntimeEnforcement:
     @pytest.fixture(scope="class")
     def expected_sql(self):
         return """
-        EXEC(' create view <model_identifier> as -- depends_on: <foreign_key_model_identifier> select ''blue'' as color, 1 as id, ''2019-01-01'' as date_day; ') EXEC(' CREATE TABLE <model_identifier> ( id int not null , color varchar(100), date_day varchar(100) ) INSERT INTO <model_identifier> ( [id], [color], [date_day] ) SELECT [id], [color], [date_day] FROM <model_identifier>  ') EXEC('DROP VIEW IF EXISTS <model_identifier>
+        EXEC(' create view <model_identifier> as -- depends_on: <foreign_key_model_identifier> select ''blue'' as color, 1 as id, ''2019-01-01'' as date_day; ') EXEC(' CREATE TABLE <model_identifier> ( id int not null , color varchar(100), date_day varchar(100) ) INSERT INTO <model_identifier> WITH (TABLOCK) ( [id], [color], [date_day] ) SELECT [id], [color], [date_day] FROM <model_identifier>  ') EXEC('DROP VIEW IF EXISTS <model_identifier>
         """
 
     def test__model_constraints_ddl(self, project, expected_sql):

--- a/tests/functional/adapter/mssql/test_tablock_hint.py
+++ b/tests/functional/adapter/mssql/test_tablock_hint.py
@@ -1,0 +1,50 @@
+import os
+
+import pytest
+
+from dbt.tests.util import run_dbt
+
+model_sql = """
+{{ config(materialized="table") }}
+select 1 as id
+"""
+
+model_yml = """
+version: 2
+models:
+  - name: contract_model
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: int
+"""
+
+
+class TestTablockHint:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "contract_model.sql": model_sql,
+            "schema.yml": model_yml,
+        }
+
+    def test_contract_table_uses_tablock(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        target_dir = os.path.join(project.project_root, "target", "run")
+        path = None
+        for root, dirs, files in os.walk(target_dir):
+            if "contract_model.sql" in files:
+                path = os.path.join(root, "contract_model.sql")
+                break
+
+        assert path is not None, "Could not find compiled contract_model.sql"
+        with open(path, "r") as f:
+            sql = f.read()
+
+        assert "WITH (TABLOCK)" in sql
+        assert "INSERT INTO" in sql


### PR DESCRIPTION
Enables minimal logging on bulk insert into pre-created tables when the database is in SIMPLE or BULK_LOGGED recovery. Fixes #640