### PR TITLE
perf: make hot-path adapter catalog queries sargable

### DIFF
--- a/dbt/include/sqlserver/macros/adapters/columns.sql
+++ b/dbt/include/sqlserver/macros/adapters/columns.sql
@@ -69,31 +69,20 @@
     {% set query_label = apply_label() %}
     {% call statement('get_columns_in_relation', fetch_result=True) %}
         {{ get_use_database_sql(relation.database) }}
-        with mapping as (
-            select
-                row_number() over (partition by object_name(c.object_id) order by c.column_id) as ordinal_position,
-                c.name collate database_default as column_name,
-                t.name as data_type,
-                case
-					when (t.name in ('nchar', 'nvarchar', 'sysname') and c.max_length <> -1) then c.max_length / 2
-					else c.max_length
-				end as character_maximum_length,
-                c.precision as numeric_precision,
-                c.scale as numeric_scale
-            from sys.columns c {{ information_schema_hints() }}
-            inner join sys.types t {{ information_schema_hints() }}
-            on c.user_type_id = t.user_type_id
-            where c.object_id = object_id('{{ 'tempdb..' ~ relation.include(database=false, schema=false) if '#' in relation.identifier else relation }}')
-        )
-
         select
-            column_name,
-            data_type,
-            character_maximum_length,
-            numeric_precision,
-            numeric_scale
-        from mapping
-        order by ordinal_position
+            c.name collate database_default as column_name,
+            t.name as data_type,
+            case
+                when (t.name in ('nchar', 'nvarchar', 'sysname') and c.max_length <> -1) then c.max_length / 2
+                else c.max_length
+            end as character_maximum_length,
+            c.precision as numeric_precision,
+            c.scale as numeric_scale
+        from sys.columns c {{ information_schema_hints() }}
+        inner join sys.types t {{ information_schema_hints() }}
+        on c.user_type_id = t.user_type_id
+        where c.object_id = object_id('{{ 'tempdb..' ~ relation.include(database=false, schema=false) if '#' in relation.identifier else relation }}')
+        order by c.column_id
         {{ query_label }}
 
     {% endcall %}

--- a/dbt/include/sqlserver/macros/adapters/metadata.sql
+++ b/dbt/include/sqlserver/macros/adapters/metadata.sql
@@ -42,23 +42,22 @@
 {% macro sqlserver__list_relations_without_caching(schema_relation) -%}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
     {{ get_use_database_sql(schema_relation.database) }}
-    with base as (
-      select
-        DB_NAME() as [database],
-        t.name as [name],
-        SCHEMA_NAME(t.schema_id) as [schema],
-        'table' as table_type
-      from sys.tables as t {{ information_schema_hints() }}
-      union all
-      select
-        DB_NAME() as [database],
-        v.name as [name],
-        SCHEMA_NAME(v.schema_id) as [schema],
-        'view' as table_type
-      from sys.views as v {{ information_schema_hints() }}
-    )
-    select * from base
-    where [schema] like '{{ schema_relation.schema }}'
+    declare @schema_id int = schema_id('{{ schema_relation.schema }}');
+    select
+      DB_NAME() as [database],
+      t.name as [name],
+      '{{ schema_relation.schema }}' as [schema],
+      'table' as table_type
+    from sys.tables as t {{ information_schema_hints() }}
+    where t.schema_id = @schema_id
+    union all
+    select
+      DB_NAME() as [database],
+      v.name as [name],
+      '{{ schema_relation.schema }}' as [schema],
+      'view' as table_type
+    from sys.views as v {{ information_schema_hints() }}
+    where v.schema_id = @schema_id
     {{ apply_label() }}
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
@@ -67,24 +66,22 @@
 {% macro sqlserver__get_relation_without_caching(schema_relation) -%}
   {% call statement('get_relation_without_caching', fetch_result=True) -%}
     {{ get_use_database_sql(schema_relation.database) }}
-    with base as (
-      select
-        DB_NAME() as [database],
-        t.name as [name],
-        SCHEMA_NAME(t.schema_id) as [schema],
-        'table' as table_type
-      from sys.tables as t {{ information_schema_hints() }}
-      union all
-      select
-        DB_NAME() as [database],
-        v.name as [name],
-        SCHEMA_NAME(v.schema_id) as [schema],
-        'view' as table_type
-      from sys.views as v {{ information_schema_hints() }}
-    )
-    select * from base
-    where [schema] like '{{ schema_relation.schema }}'
-    and [name] like '{{ schema_relation.identifier }}'
+    declare @schema_id int = schema_id('{{ schema_relation.schema }}');
+    select
+      DB_NAME() as [database],
+      t.name as [name],
+      '{{ schema_relation.schema }}' as [schema],
+      'table' as table_type
+    from sys.tables as t {{ information_schema_hints() }}
+    where t.schema_id = @schema_id and t.name = '{{ schema_relation.identifier }}'
+    union all
+    select
+      DB_NAME() as [database],
+      v.name as [name],
+      '{{ schema_relation.schema }}' as [schema],
+      'view' as table_type
+    from sys.views as v {{ information_schema_hints() }}
+    where v.schema_id = @schema_id and v.name = '{{ schema_relation.identifier }}'
     {{ apply_label() }}
   {% endcall %}
   {{ return(load_result('get_relation_without_caching').table) }}
@@ -96,12 +93,8 @@
 
 {% macro sqlserver__get_view_definition_sql(relation) -%}
   {{ get_use_database_sql(relation.database) }}
-  select object_definition(v.object_id) as definition
-  from sys.views as v {{ information_schema_hints() }}
-  inner join sys.schemas as s {{ information_schema_hints() }}
-    on v.schema_id = s.schema_id
-  where upper(s.name) = upper('{{ relation.schema }}')
-    and upper(v.name) = upper('{{ relation.identifier }}')
+  select object_definition(object_id('[{{ relation.schema }}].[{{ relation.identifier }}]', 'V')) as definition
+  where object_id('[{{ relation.schema }}].[{{ relation.identifier }}]', 'V') is not null
 {% endmacro %}
 
 {% macro sqlserver__get_relation_last_modified(information_schema, relations) -%}

--- a/dbt/include/sqlserver/macros/adapters/metadata.sql
+++ b/dbt/include/sqlserver/macros/adapters/metadata.sql
@@ -92,9 +92,10 @@
 {% endmacro %}
 
 {% macro sqlserver__get_view_definition_sql(relation) -%}
+  {%- set object_name = "quotename('" ~ relation.schema ~ "') + '.' + quotename('" ~ relation.identifier ~ "')" -%}
   {{ get_use_database_sql(relation.database) }}
-  select object_definition(object_id('[{{ relation.schema }}].[{{ relation.identifier }}]', 'V')) as definition
-  where object_id('[{{ relation.schema }}].[{{ relation.identifier }}]', 'V') is not null
+  select object_definition(object_id({{ object_name }}, 'V')) as definition
+  where object_id({{ object_name }}, 'V') is not null
 {% endmacro %}
 
 {% macro sqlserver__get_relation_last_modified(information_schema, relations) -%}

--- a/tests/functional/adapter/mssql/test_get_view_definition.py
+++ b/tests/functional/adapter/mssql/test_get_view_definition.py
@@ -1,0 +1,57 @@
+import pytest
+
+from dbt.tests.util import run_dbt_and_capture
+
+# Builds a relation for the given schema/identifier and runs the adapter's
+# get_view_definition_sql against it, logging whether a definition row came
+# back. Lets the tests assert the macro's behaviour directly instead of going
+# through the full view materialization.
+VALIDATE_GET_VIEW_DEFINITION_MACRO = """
+{% macro validate_get_view_definition_sql(schema, identifier) -%}
+    {% set relation = api.Relation.create(
+        database=target.database, schema=schema, identifier=identifier, type='view'
+    ) %}
+    {% set result = run_query(get_view_definition_sql(relation)) %}
+    {% if result is not none and result.rows | length > 0 and result.rows[0][0] is not none %}
+        {{ log("view_definition_found: true") }}
+    {% else %}
+        {{ log("view_definition_found: false") }}
+    {% endif %}
+{% endmacro %}
+"""
+
+
+class TestGetViewDefinitionSql:
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"validate_get_view_definition_sql.sql": VALIDATE_GET_VIEW_DEFINITION_MACRO}
+
+    def _resolve(self, schema, identifier):
+        kwargs = {"schema": schema, "identifier": identifier}
+        _, log_output = run_dbt_and_capture(
+            [
+                "--debug",
+                "run-operation",
+                "validate_get_view_definition_sql",
+                "--args",
+                str(kwargs),
+            ]
+        )
+        return log_output
+
+    def test_resolves_identifier_containing_right_bracket(self, project):
+        """A legal identifier containing ``]`` must still resolve. quotename()
+        doubles the ``]`` so OBJECT_ID gets a valid object name; the old manual
+        bracket-quoting produced a malformed name and returned NULL."""
+        identifier = "weird]name"
+        # ``]`` is escaped by doubling it inside a bracketed identifier.
+        project.run_sql(f"create view {project.test_schema}.[weird]]name] as select 1 as id")
+
+        log_output = self._resolve(project.test_schema, identifier)
+        assert "view_definition_found: true" in log_output
+
+    def test_missing_view_returns_no_rows(self, project):
+        """A view that does not exist yields zero rows, which the view
+        materialization relies on to fall through to a create."""
+        log_output = self._resolve(project.test_schema, "does_not_exist")
+        assert "view_definition_found: false" in log_output


### PR DESCRIPTION
Optimizes the four highest-frequency catalog queries in the SQL Server adapter so they seek instead of scan:

- `list_relations_without_caching`: filter by schema_id = SCHEMA_ID(@schema) before computing names, instead of scanning every table+view in the database and post-filtering with LIKE on SCHEMA_NAME(...).
- `get_relation_without_caching`: same predicate-pushdown; also switch identifier match from LIKE (no wildcards) to equality.
- `get_columns_in_relation`: drop the wrapping CTE and the no-op ROW_NUMBER() OVER (PARTITION BY object_name(c.object_id) ...); the WHERE already pins one object_id. Order directly by c.column_id.
- `get_view_definition_sql`: replace UPPER()-on-both-sides join across sys.views + sys.schemas with a single OBJECT_DEFINITION(OBJECT_ID( '[schema].[name]', 'V')) lookup. Preserves zero-row behavior when the view doesn't exist so the view materialization's diff-skip logic is unchanged.