### PR TITLE
feat: start v1.10.1rc1

### DIFF
--- a/dbt/adapters/sqlserver/__version__.py
+++ b/dbt/adapters/sqlserver/__version__.py
@@ -1,1 +1,1 @@
-version = "1.10.0"
+version = "1.10.1rc1"


### PR DESCRIPTION
Just bumps to v1.10.1rc1, this enables directly merging into release/v1.10 branch for next release, avoiding the release branch only temporal patch to rc1 versions