### PR TITLE
Correctness fixes: LABEL escaping, dead columnstore guard, init port, misc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       - id: black
         args:
           - '--line-length=99'
-          - '--target-version=py39'
+          - '--target-version=py310'
       - id: black
         alias: black-check
         stages:

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ server: ## Spins up a local MS SQL Server instance for development. Docker-compo
 	docker compose up -d
 
 .PHONY: clean
+clean: ## Removes ignored files and build artifacts from the repo.
 	@echo "cleaning repo"
 	@git clean -f -X
 

--- a/README.md
+++ b/README.md
@@ -98,51 +98,30 @@ See [the changelog](CHANGELOG.md)
 
 ## Configuration
 
-- `dbt_sqlserver_use_default_schema_concat`: *(default: `false`)* Controls schema name generation when a [custom schema](https://docs.getdbt.com/docs/build/custom-schemas) is set on a model.
-
-  | Flag value | `custom_schema_name` | Result |
-  |---|---|---|
-  | `false` (default, legacy) | *(none)* | `target.schema` |
-  | `false` (default, legacy) | `"reporting"` | `reporting` |
-  | `true` (dbt-core standard) | *(none)* | `target.schema` |
-  | `true` (dbt-core standard) | `"reporting"` | `target.schema_reporting` |
-
-  When `false` (the default), the adapter uses its legacy behaviour: `custom_schema_name` is used **as-is** without being prefixed by `target.schema`.  
-  When `true`, the adapter delegates to dbt-core's `default__generate_schema_name`, which concatenates `target.schema` + `_` + `custom_schema_name`.
-
-  **Example usage in `dbt_project.yml`:**
-
-  ```yaml
-  flags:
-    dbt_sqlserver_use_default_schema_concat: true  # Enable standard schema concatenation
-  ```
-
-  This adapter also supports the same setting via `vars:` for backwards compatibility, so either method works in the current release.
-
-  > **Note:** If you want to permanently customise schema generation and avoid any future changes, override the `sqlserver__generate_schema_name` macro directly in your project instead.
-
-
 ### `dbt_sqlserver_use_default_schema_concat`
 
 *(default: `false`)* Controls schema name generation when a [custom schema](https://docs.getdbt.com/docs/build/custom-schemas) is set on a model.
 
-| Value | `custom_schema_name` | Result |
+| Flag value | `custom_schema_name` | Result |
 |---|---|---|
-| `false` (default) | *(none)* | `target.schema` |
-| `false` (default) | `"reporting"` | `reporting` |
-| `true` | *(none)* | `target.schema` |
-| `true` | `"reporting"` | `target.schema_reporting` |
+| `false` (default, legacy) | *(none)* | `target.schema` |
+| `false` (default, legacy) | `"reporting"` | `reporting` |
+| `true` (dbt-core standard) | *(none)* | `target.schema` |
+| `true` (dbt-core standard) | `"reporting"` | `target.schema_reporting` |
 
-When `false`, `custom_schema_name` is used as-is without being prefixed by `target.schema`.  
-When `true`, the adapter delegates to dbt-core's `default__generate_schema_name`.
+When `false` (the default), the adapter uses its legacy behaviour: `custom_schema_name` is used **as-is** without being prefixed by `target.schema`.  
+When `true`, the adapter delegates to dbt-core's `default__generate_schema_name`, which concatenates `target.schema` + `_` + `custom_schema_name`.
+
+**Example usage in `dbt_project.yml`:**
 
 ```yaml
-# dbt_project.yml
-vars:
-  dbt_sqlserver_use_default_schema_concat: true
+flags:
+  dbt_sqlserver_use_default_schema_concat: true  # Enable standard schema concatenation
 ```
 
-> **Note:** To permanently customise schema generation without a flag dependency, override the `sqlserver__generate_schema_name` macro directly in your project.
+The same setting is also honoured via `vars:` for backwards compatibility; the behavior flag under `flags:` takes precedence when both are set.
+
+> **Note:** If you want to permanently customise schema generation and avoid any future changes, override the `sqlserver__generate_schema_name` macro directly in your project instead.
 
 ### `backend`
 

--- a/dbt/adapters/sqlserver/sqlserver_constants.py
+++ b/dbt/adapters/sqlserver/sqlserver_constants.py
@@ -102,7 +102,7 @@ datatypes = {
     "str": "varchar",
     "uuid.UUID": "uniqueidentifier",
     "uuid": "uniqueidentifier",
-    "float": "bigint",
+    "float": "float",
     "int": "int",
     "bytes": "varbinary",
     "bytearray": "varbinary",

--- a/dbt/include/sqlserver/macros/adapters/indexes.sql
+++ b/dbt/include/sqlserver/macros/adapters/indexes.sql
@@ -1,6 +1,6 @@
 {% macro sqlserver__create_clustered_columnstore_index(relation) -%}
     {%- set cci_name = (relation.schema ~ '_' ~ relation.identifier ~ '_cci') | replace(".", "") | replace(" ", "") -%}
-    {%- set relation_name = relation.schema ~ '_' ~ relation.identifier -%}
+    {%- set relation_name = relation.include(database=False) -%}
     {%- set full_relation = '"' ~ relation.schema ~ '"."' ~ relation.identifier ~ '"' -%}
     use [{{ relation.database }}];
     if EXISTS (

--- a/dbt/include/sqlserver/macros/adapters/metadata.sql
+++ b/dbt/include/sqlserver/macros/adapters/metadata.sql
@@ -1,6 +1,7 @@
 {% macro get_query_options(parse_options=False) %}
     {{ log (config.get('query_tag','dbt-sqlserver'))}}
-    {%- set query_label = config.get('query_tag','dbt-sqlserver') -%}
+    {#- Escape single quotes so a query_tag like "it's" can't break out of the LABEL literal. -#}
+    {%- set query_label = escape_single_quotes(config.get('query_tag','dbt-sqlserver')) -%}
     {%- set query_options = config.get('query_options', {}) -%}
     {%- set query_options_raw = config.get('query_options_raw', []) -%}
 
@@ -77,7 +78,7 @@
     incremental, snapshot, unit_test), override get_query_options instead. -#}
 {% macro apply_label() %}
     {{ log (config.get('query_tag','dbt-sqlserver'))}}
-    {%- set query_label = config.get('query_tag','dbt-sqlserver') -%}
+    {%- set query_label = escape_single_quotes(config.get('query_tag','dbt-sqlserver')) -%}
     OPTION (LABEL = '{{query_label}}');
 {% endmacro %}
 

--- a/dbt/include/sqlserver/macros/materializations/models/incremental/incremental_strategies.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/incremental/incremental_strategies.sql
@@ -1,7 +1,7 @@
 {% macro sqlserver__get_incremental_default_sql(arg_dict) %}
 
     {% if arg_dict["unique_key"] %}
-        -- Delete + Insert Strategy, calls get_delete_insert_merge_sql
+        -- Merge strategy: emits a MERGE statement via get_incremental_merge_sql
         {% do return(get_incremental_merge_sql(arg_dict)) %}
     {% else %}
         -- Incremental Append will insert data into target table.

--- a/dbt/include/sqlserver/profile_template.yml
+++ b/dbt/include/sqlserver/profile_template.yml
@@ -4,7 +4,7 @@ prompts:
   host:
     hint: "your host name"
   port:
-    default: 5432
+    default: 1433
     type: "int"
   user:
     hint: "dev username"


### PR DESCRIPTION
Batch of small, independent correctness fixes. Every change was verified against a live SQL Server 2022 container (`devops/server.Dockerfile` image): the relevant functional suites (`test_query_options`, `test_index`, `test_data_types`) pass, unit tests pass **110/110**, and each fix has a targeted reproduction described below.

> **Note:** this batch originally also fixed the `sys.types` join in the catalog queries (joining on `system_type_id`, which is not unique, fans out and produces duplicate rows / wrong type names for UDT and `sysname` columns). That commit was dropped while merging `master`: #289 (persist-docs) independently fixed the same join, so the fix is already on `master` and is no longer part of this PR.

> **Note:** this batch originally also added `SET XACT_ABORT ON` to the dml-refresh swap (preventing a failed swap from committing an empty target). That commit has been **removed from this PR**: the transaction/DML behavior is being handled in #710 (`dbt_sqlserver_use_dbt_transactions`), which modifies the same swap macro. To keep these correctness fixes independent of that work — and avoid a conflict on the same file — the change is dropped here and deferred to #710.

---

### 1. `dbt init` suggested the Postgres port

**Issue:** `profile_template.yml` shipped `port: default: 5432` — the Postgres port — so every `dbt init` user accepting defaults got a non-working profile.

**Solution:** Default changed to 1433. Verified through dbt's own `InitTask.generate_target_from_input` code path: accepting the default yields `port: 1433` (int).

### 2. Python `float` mapped to SQL Server `bigint`

**Issue:** The `datatypes` mapping in `sqlserver_constants.py` (consumed by `SQLServerConnectionManager.data_type_code_to_name` to report column type names for query metadata) translated Python `float` to `"bigint"`.

**Solution:** Map it to `"float"`. Verified live: a `cast(1.5 as float)` result column produces cursor `type_code = <class 'float'>`, which now resolves to `float`.

### 3. A single quote in `query_tag` broke every emitted query (and allowed OPTION-clause injection)

**Issue:** `get_query_options()` (and the deprecated `apply_label()`) interpolated the user-supplied `query_tag` config into `OPTION (LABEL = '...')` without escaping. A tag containing `'` produced a syntax error in **every** statement the adapter emits for that model; a crafted tag could inject arbitrary text into the OPTION clause.

**Solution:** Escape via dbt's cross-adapter `escape_single_quotes()` macro (quote doubling `'` → `''` on this adapter; the same helper the `EXEC('...')` wrappers in this repo already use) at both build sites in `metadata.sql`. Verified: a model with `query_tag: "rob's o'clock tag"` builds cleanly on both code paths, including statements wrapped in `EXEC('...')` (where the pre-escaped label composes correctly with the wrapper's own quote doubling), and the full `test_query_options` functional suite passes (26/26) against a live SQL Server 2022.

### 4. Columnstore-index existence guard was dead code; misleading comment on the default incremental strategy

**Issue:** `sqlserver__create_clustered_columnstore_index` guarded its `DROP INDEX` with `object_id('<schema>_<table>')` — an underscore-joined name that never resolves (verified live: always NULL). The `IF EXISTS` branch could therefore never fire, and re-creating a CCI on a table that already has one fails with "You cannot create more than one clustered index". Separately, the comment in `incremental_strategies.sql` claimed the default strategy with a `unique_key` performs delete+insert, when it actually emits a `MERGE` via `get_incremental_merge_sql`.

**Solution:** Use the relation's own quoted rendering — `relation.include(database=False)`, which emits `object_id('"schema"."table"')` — in `indexes.sql`; the guard now finds the existing index and the macro drops + recreates it. Verified live: `OBJECT_ID` resolves the double-quoted form identically to brackets (including under `QUOTED_IDENTIFIER OFF`), and re-running the rendered batch against a table with an existing CCI drops and recreates it instead of failing. Comment corrected to say MERGE (separate commit).

*Known pre-existing limitation, unchanged here:* tables built via a `__dbt_tmp` intermediate + rename keep the index name `<schema>_<table>__dbt_tmp_cci`, which the macro's computed name does not match, so the guard cannot protect that case.

### 5. Docs/tooling: duplicated README section, black target py39, broken `make clean`

- **README** documented `dbt_sqlserver_use_default_schema_concat` twice, with conflicting `flags:`-vs-`vars:` guidance. Merged into a single section matching the actual implementation (`schema.sql:61-63`: behavior flag first, `vars` as backwards-compat fallback).
- **pre-commit**: the auto `black` hook still used `--target-version=py39`, while `requires-python >= 3.10` and the manual `black-check` hook already targeted py310. Bumped the auto hook to py310 to match. (The original commit also bumped the `isort` target, but #707 has since consolidated isort/flake8/pycln/absolufy-imports into ruff on `master`; after rebasing onto that, only the black target bump remains.) Verified black at py310 changes zero files, so no reformatting churn for contributors.
- **Makefile**: the `clean` target had a `.PHONY` declaration and recipe lines but the `clean:` rule line itself was missing, so `make clean` did nothing. Restored (and it now shows in `make help`).

(Each of these three is its own commit.)
