### PR TITLE
chore: consolidate isort, flake8, pycln and absolufy-imports into ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,28 +27,16 @@ repos:
         args:
           - '-d {extends: default, rules: {line-length: disable, document-start: disable}}'
           - '-s'
-  - repo: 'https://github.com/MarcoGorelli/absolufy-imports'
-    rev: v0.3.1
+  - repo: 'https://github.com/astral-sh/ruff-pre-commit'
+    rev: v0.15.17
     hooks:
-      - id: absolufy-imports
-  - repo: 'https://github.com/hadialqattan/pycln'
-    rev: v2.6.0
-    hooks:
-      - id: pycln
+      - id: ruff-check
         args:
-          - '--all'
-  - repo: 'https://github.com/pycqa/isort'
-    rev: 9.0.0a3
-    hooks:
-      - id: isort
-        args:
-          - '--profile'
-          - black
-          - '--atomic'
-          - '--line-length'
-          - '99'
-          - '--python-version'
-          - '39'
+          - '--fix'
+      - id: ruff-check
+        alias: ruff-check-manual
+        stages:
+          - manual
   - repo: 'https://github.com/psf/black'
     rev: 26.5.1
     hooks:
@@ -65,18 +53,6 @@ repos:
           - '--target-version=py310'
           - '--check'
           - '--diff'
-  - repo: 'https://github.com/pycqa/flake8'
-    rev: 7.3.0
-    hooks:
-      - id: flake8
-        args:
-          - '--max-line-length=99'
-      - id: flake8
-        args:
-          - '--max-line-length=99'
-        alias: flake8-check
-        stages:
-          - manual
   - repo: 'https://github.com/pre-commit/mirrors-mypy'
     rev: v2.1.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ mypy: ## Runs mypy against staged changes for static type checking.
 	@\
 	pre-commit run --hook-stage manual mypy-check | grep -v "INFO"
 
-.PHONY: flake8
-flake8: ## Runs flake8 against staged changes to enforce style guide.
+.PHONY: ruff
+ruff: ## Runs ruff against staged changes to enforce style guide.
 	@\
-	pre-commit run --hook-stage manual flake8-check | grep -v "INFO"
+	pre-commit run --hook-stage manual ruff-check-manual | grep -v "INFO"
 
 .PHONY: black
 black: ## Runs black  against staged changes to enforce style guide.
@@ -22,20 +22,15 @@ black: ## Runs black  against staged changes to enforce style guide.
 	pre-commit run --hook-stage manual black-check -v | grep -v "INFO"
 
 .PHONY: lint
-lint: ## Runs flake8 and mypy code checks against staged changes.
+lint: ## Runs ruff and mypy code checks against staged changes.
 	@\
-	pre-commit run flake8-check --hook-stage manual | grep -v "INFO"; \
+	pre-commit run ruff-check-manual --hook-stage manual | grep -v "INFO"; \
 	pre-commit run mypy-check --hook-stage manual | grep -v "INFO"
 
 .PHONY: all
 all: ## Runs all checks against staged changes.
 	@\
 	pre-commit run -a
-
-.PHONY: linecheck
-linecheck: ## Checks for all Python lines 100 characters or more
-	@\
-	find dbt -type f -name "*.py" -exec grep -I -r -n '.\{100\}' {} \;
 
 .PHONY: unit
 unit: ## Runs unit tests.
@@ -52,7 +47,7 @@ test: ## Runs unit tests and code checks against staged changes.
 	@\
 	pytest -n auto -ra -v tests/unit; \
 	pre-commit run black-check --hook-stage manual | grep -v "INFO"; \
-	pre-commit run flake8-check --hook-stage manual | grep -v "INFO"; \
+	pre-commit run ruff-check-manual --hook-stage manual | grep -v "INFO"; \
 	pre-commit run mypy-check --hook-stage manual | grep -v "INFO"
 
 .PHONY: server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,19 @@ namespaces = true
 
 [tool.uv]
 link-mode = "copy"
+
+[tool.ruff]
+line-length = 99
+target-version = "py310"
+
+[tool.ruff.lint]
+# E/W = pycodestyle, F = pyflakes (together: flake8), I = isort,
+# TID252 = no relative imports (absolufy-imports); unused-import
+# removal (pycln) is F401, included in F
+select = ["E", "F", "W", "I", "TID252"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["dbt"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"


### PR DESCRIPTION
## Summary

This PR consolidates four of the five Python lint/format tools in our pre-commit config — `absolufy-imports`, `pycln`, `isort`, and `flake8` — into a single [Ruff](https://docs.astral.sh/ruff/) hook configured in `pyproject.toml`. **black and mypy are unchanged.**

It is a config-only change: `ruff check` passes with **zero findings** on the current codebase (verified against master at 10df88a, ruff 0.15.17), so no Python source is touched and there is no churn to review beyond the three config files.

`ruff` has been in our dev dependency group since the PEP 621 packaging migration (9b8b82a) but was never wired up — this PR puts it to use.

## Why

1. **`absolufy-imports` is unmaintained.** The repo was [archived on July 3, 2024](https://github.com/MarcoGorelli/absolufy-imports) and its README states: *"This tool has been superseded by Ruff. Please use that instead."*
2. **Our isort hook was pinned to a prerelease** (`9.0.0a3`), which is fragile.
3. **Fewer moving parts.** Four pre-commit hook repos become one; per-hook CLI args scattered across `.pre-commit-config.yaml` become one `[tool.ruff]` block in `pyproject.toml`.
4. **Speed.** Ruff checks the whole repo in ~0.05s (the flake8 hook alone takes ~2s through pre-commit), which makes adding a lint job to CI essentially free if we want one later.

## Rule mapping

| Removed tool | Ruff equivalent |
|---|---|
| flake8 (`--max-line-length=99`) | `E`, `F`, `W` with `line-length = 99` |
| isort (`--profile black --line-length 99`) | `I` with `known-first-party = ["dbt"]` |
| pycln (`--all`) | `F401` (included in `F`) |
| absolufy-imports | `TID252` with `ban-relative-imports = "all"` |
| `make linecheck` (grep for lines ≥100 chars) | `E501` (included in `E`) |

I verified each rule family actually fires by probing with a deliberately bad file (unsorted imports, unused import, relative import, 126-char line) — all flagged as expected.

Makefile changes: `make flake8` → `make ruff`; `make lint` / `make test` updated accordingly; `make linecheck` removed as redundant with E501.

## Notes and trade-offs

- **Rule parity isn't 100%:** Ruff implements all of pyflakes and most of pycodestyle; a few whitespace-nitpick pycodestyle rules are preview-only. Since black already enforces formatting, this gap is immaterial here (empirically: zero findings either way today).
- **`ruff format` is deliberately out of scope.** It would reformat 11 of 79 files (cosmetic differences from black). Keeping black means this PR causes zero source churn. Happy to discuss the formatter swap separately if there's interest.
- **Heads-up:** this will conflict slightly with #706, which also touches `.pre-commit-config.yaml` and the Makefile. The conflicts are trivial; happy to rebase whichever lands second.

## Checklist

- [x] `ruff check dbt tests` passes with zero findings (config-only change)
- [x] `.pre-commit-config.yaml` validates (`pre-commit validate-config` + yamllint)
- [x] No changes to Python source, black, or mypy configuration
