### PR TITLE
fix: guard run_hooks commit with @@trancount check for autocommit safety

### DIFF
--- a/dbt/include/sqlserver/macros/materializations/hooks.sql
+++ b/dbt/include/sqlserver/macros/materializations/hooks.sql
@@ -1,0 +1,15 @@
+{% macro run_hooks(hooks, inside_transaction=True) %}
+  {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}
+    {% if not inside_transaction and loop.first %}
+      {% call statement(auto_begin=inside_transaction) %}
+        if @@trancount > 0 commit;
+      {% endcall %}
+    {% endif %}
+    {% set rendered = render(hook.get('sql')) | trim %}
+    {% if (rendered | length) > 0 %}
+      {% call statement(auto_begin=inside_transaction) %}
+        {{ rendered }}
+      {% endcall %}
+    {% endif %}
+  {% endfor %}
+{% endmacro %}

--- a/tests/functional/adapter/dbt/test_hooks.py
+++ b/tests/functional/adapter/dbt/test_hooks.py
@@ -232,3 +232,28 @@ class BaseHookRefs(BaseTestPrePost):
 
 class TestHookRefs(BaseHookRefs):
     pass
+
+
+class BaseAfterCommitModelHook(BaseTestPrePost):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "test": {
+                    "post-hook": [
+                        {"sql": "select 1", "transaction": False},
+                    ],
+                }
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"after_commit_hook_model.sql": "select 1 as id"}
+
+    def test_after_commit_post_hook_does_not_double_commit(self, project):
+        run_dbt()
+
+
+class TestAfterCommitModelHook(BaseAfterCommitModelHook):
+    pass


### PR DESCRIPTION
dbt-core's run_hooks macro emits a bare 'commit;' before running inside_transaction=False hooks (after_commit). With autocommit=True there is no open SQL Server transaction, causing error 3902. Closes #444

Override run_hooks for the sqlserver adapter, replacing the bare commit with 'if @@trancount > 0 commit;' which only commits when a transaction is actually open.

Add TestAfterCommitModelHook regression test that creates a table model with an after_commit post-hook and verifies it runs without error.

Follow up: #708