### PR TITLE
Implements `dbt_sqlserver_use_dbt_transactions` behavior flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,24 @@ The same setting is also honoured via `vars:` for backwards compatibility; the b
 
 *(default: `pyodbc`)* Set to `mssql-python` in a profile target to use the `mssql-python` backend instead of `pyodbc`. The adapter fails if the required backend package (Python dependency), such as `pyodbc` or `mssql-python`, is not installed.
 
+### `dbt_sqlserver_use_dbt_transactions`
+
+_(default: `false`)_ When enabled, makes dbt's transaction hooks real at the SQL Server level by emitting `BEGIN TRANSACTION` / `COMMIT TRANSACTION` through the adapter's `add_begin_query` and `add_commit_query` methods. 
+
+The default is `false`, preserving existing behavior where `begin`/`commit` hooks are logical no-ops and the ODBC driver auto-commits each statement. When `dbt_sqlserver_use_dbt_transactions: true`, the adapter emits real T-SQL transaction statements, and rollback uses `IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION`.
+
+The driver connection remains in autocommit mode (`autocommit=true`) in both modes.
+
+This mode is opt-in and should be tested carefully with project-specific materializations and hooks.
+
+```yaml
+# dbt_project.yml
+flags:
+    dbt_sqlserver_use_dbt_transactions: true # <-- opt-in; default is false
+```
+
+**Compatibility notes:** Enabling `dbt_sqlserver_use_dbt_transactions: true` may expose transaction-state assumptions hidden by autocommit-only mode. Explicit transaction macros may interact with dbt-managed transactions, and cleanup after failed DDL/DML may differ. Review pre/post hooks for in-transaction vs out-of-transaction semantics.
+
 ## Contributing
 
 [![Unit tests](https://github.com/dbt-msft/dbt-sqlserver/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/dbt-msft/dbt-sqlserver/actions/workflows/unit-tests.yml)

--- a/dbt/adapters/sqlserver/sqlserver_adapter.py
+++ b/dbt/adapters/sqlserver/sqlserver_adapter.py
@@ -62,6 +62,11 @@ class SQLServerAdapter(SQLAdapter):
         )
         if self.behavior.dbt_sqlserver_use_native_string_types:
             self.Column = SQLServerColumnNative
+        # add_begin_query/add_commit_query read the instance flag, while dbt-core
+        # rollback handling is classmethod-based and reads the class flag.
+        use_dbt_transactions = bool(self.behavior.dbt_sqlserver_use_dbt_transactions)
+        SQLServerConnectionManager._dbt_sqlserver_use_dbt_transactions = use_dbt_transactions
+        self.connections._dbt_sqlserver_use_dbt_transactions = use_dbt_transactions
 
     @property
     def _behavior_flags(self) -> List[BehaviorFlag]:
@@ -104,6 +109,18 @@ class SQLServerAdapter(SQLAdapter):
                     "When False (default), preserves legacy mappings: "
                     "STRING and NVARCHAR -> VARCHAR(8000), NCHAR -> CHAR(1). "
                     "The new behaviour is intended to become the default in a future release."
+                ),
+            },
+            {
+                "name": "dbt_sqlserver_use_dbt_transactions",
+                "default": False,
+                "description": (
+                    "When True, dbt transaction hooks (begin/commit) emit real T-SQL "
+                    "BEGIN TRANSACTION / COMMIT TRANSACTION statements. "
+                    "When False (default and legacy), begin/commit are no-ops and each statement "
+                    "is auto-committed by the driver. This means earlier successful statements "
+                    "are not rolled back if a later statement fails. "
+                    "This behavior is intended to become the default in a future release."
                 ),
             },
         ]

--- a/dbt/adapters/sqlserver/sqlserver_connections.py
+++ b/dbt/adapters/sqlserver/sqlserver_connections.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import time
+import traceback
 from contextlib import contextmanager
 from typing import (
     Any,
@@ -25,6 +26,7 @@ from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.events.types import (
     AdapterEventDebug,
     ConnectionUsed,
+    RollbackFailed,
     SQLQuery,
     SQLQueryStatus,
 )
@@ -62,6 +64,8 @@ logger = AdapterLogger("sqlserver")
 
 class SQLServerConnectionManager(SQLConnectionManager):
     TYPE = "sqlserver"
+
+    _dbt_sqlserver_use_dbt_transactions: bool = False
 
     @contextmanager
     def exception_handler(self, sql):
@@ -142,10 +146,42 @@ class SQLServerConnectionManager(SQLConnectionManager):
         logger.debug("Cancel query")
 
     def add_begin_query(self):
-        pass
+        if self._dbt_sqlserver_use_dbt_transactions:
+            return self.add_query("BEGIN TRANSACTION", auto_begin=False)
 
     def add_commit_query(self):
-        pass
+        if self._dbt_sqlserver_use_dbt_transactions:
+            return self.add_query("IF @@TRANCOUNT > 0 COMMIT TRANSACTION", auto_begin=False)
+
+    @classmethod
+    def _rollback_handle(cls, connection: Connection) -> None:
+        if cls._dbt_sqlserver_use_dbt_transactions:
+            cursor = None
+            try:
+                cursor = connection.handle.cursor()
+                cursor.execute("IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION")
+            except Exception:
+                fire_event(
+                    RollbackFailed(
+                        conn_name=cast_to_str(connection.name),
+                        exc_info=traceback.format_exc(),
+                        node_info=get_node_info(),
+                    )
+                )
+            finally:
+                if cursor is not None:
+                    cursor.close()
+        else:
+            try:
+                connection.handle.rollback()
+            except Exception:
+                fire_event(
+                    RollbackFailed(
+                        conn_name=cast_to_str(connection.name),
+                        exc_info=traceback.format_exc(),
+                        node_info=get_node_info(),
+                    )
+                )
 
     def add_query(
         self,

--- a/dbt/include/sqlserver/macros/materializations/hooks.sql
+++ b/dbt/include/sqlserver/macros/materializations/hooks.sql
@@ -2,7 +2,11 @@
   {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}
     {% if not inside_transaction and loop.first %}
       {% call statement(auto_begin=inside_transaction) %}
-        if @@trancount > 0 commit;
+        {% if not adapter.behavior.dbt_sqlserver_use_dbt_transactions %}
+          if @@trancount > 0 commit; -- post hooks after fictitious transaction work as expected
+        {% else %}
+          commit; -- align transaction=False hook behavior with dbt-core transaction semantics.
+        {% endif %}
       {% endcall %}
     {% endif %}
     {% set rendered = render(hook.get('sql')) | trim %}

--- a/dbt/include/sqlserver/macros/materializations/models/table/table_dml_refresh.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/table/table_dml_refresh.sql
@@ -55,17 +55,18 @@
 
     {# Atomic DML swap — RCSI protects concurrent readers #}
     {# When dbt_sqlserver_use_dbt_transactions is off (default), autocommit #}
-    {# ensures only this explicit transaction exists. When the flag is on, #}
-    {# the statement call auto-begins an outer transaction first. SQL Server #}
-    {# increments @@TRANCOUNT for nested BEGIN TRANSACTION statements. #}
-    {# Inner COMMIT only decrements @@TRANCOUNT; durability occurs when the outermost #}
-    {# transaction commits. A ROLLBACK rolls back the full transaction. #}
+    {# means we need the explicit BEGIN/COMMIT. When the flag is on, dbt #}
+    {# already wraps the statement call in a transaction, so skip it. #}
     {% call statement('dml_refresh_swap') -%}
+      {% if not adapter.behavior.dbt_sqlserver_use_dbt_transactions %}
       BEGIN TRANSACTION;
+      {% endif %}
       DELETE FROM {{ target_relation }};
       INSERT INTO {{ target_relation }} ({{ column_list }})
         SELECT {{ column_list }} FROM {{ refresh_relation }};
+      {% if not adapter.behavior.dbt_sqlserver_use_dbt_transactions %}
       COMMIT TRANSACTION;
+      {% endif %}
     {%- endcall %}
 
     {# Cleanup scratch table #}

--- a/dbt/include/sqlserver/macros/materializations/models/table/table_dml_refresh.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/table/table_dml_refresh.sql
@@ -54,8 +54,12 @@
     {%- set column_list = target_columns | map(attribute='quoted') | join(', ') -%}
 
     {# Atomic DML swap — RCSI protects concurrent readers #}
-    {# dbt-sqlserver uses autocommit=True and add_begin_query/add_commit_query #}
-    {# are no-ops, so this creates a simple (non-nested) transaction. #}
+    {# When dbt_sqlserver_use_dbt_transactions is off (default), autocommit #}
+    {# ensures only this explicit transaction exists. When the flag is on, #}
+    {# the statement call auto-begins an outer transaction first. SQL Server #}
+    {# increments @@TRANCOUNT for nested BEGIN TRANSACTION statements. #}
+    {# Inner COMMIT only decrements @@TRANCOUNT; durability occurs when the outermost #}
+    {# transaction commits. A ROLLBACK rolls back the full transaction. #}
     {% call statement('dml_refresh_swap') -%}
       BEGIN TRANSACTION;
       DELETE FROM {{ target_relation }};

--- a/tests/functional/adapter/dbt/test_transactions.py
+++ b/tests/functional/adapter/dbt/test_transactions.py
@@ -174,3 +174,48 @@ select 1/0 as boom
         rows = project.run_sql("select id from {schema}.good_model", fetch="all")
         assert len(rows) == 1
         assert rows[0][0] == 1
+
+
+_snapshot_seed_csv = """id,name,updated_at
+1,alice,2024-01-01 00:00:00
+2,bob,2024-01-01 00:00:00
+"""
+
+_snapshot_sql = """
+{% snapshot snap %}
+{{ config(
+    target_schema=schema,
+    unique_key='id',
+    strategy='timestamp',
+    updated_at='updated_at',
+) }}
+select * from {{ ref('snap_seed') }}
+{% endsnapshot %}
+"""
+
+
+class TestSnapshotTransactionsOn(BaseTransactionsEnabled):
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"snap_seed.csv": _snapshot_seed_csv}
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {"snap.sql": _snapshot_sql}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {}
+
+    def test_snapshot_create_and_merge(self, project):
+        run_dbt(["seed"])
+        results = run_dbt(["snapshot"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        rows = project.run_sql("select count(*) from {schema}.snap", fetch="one")
+        assert rows[0] == 2
+
+        results = run_dbt(["snapshot"])
+        assert len(results) == 1
+        assert results[0].status == "success"

--- a/tests/functional/adapter/dbt/test_transactions.py
+++ b/tests/functional/adapter/dbt/test_transactions.py
@@ -1,0 +1,176 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+
+class BaseTransactionsEnabled:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"dbt_sqlserver_use_dbt_transactions": True}}
+
+
+class TestTableMaterializationTransactionsOn(BaseTransactionsEnabled):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table_model.sql": """
+{{ config(materialized='table') }}
+select 1 as id, 'hello' as name
+""",
+        }
+
+    def test_table_materialization(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        rows = project.run_sql("select id, name from {schema}.table_model", fetch="all")
+        assert len(rows) == 1
+        assert rows[0][0] == 1
+        assert rows[0][1] == "hello"
+
+
+class TestViewMaterializationTransactionsOn(BaseTransactionsEnabled):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "view_model.sql": """
+{{ config(materialized='view') }}
+select 42 as answer
+""",
+        }
+
+    def test_view_materialization(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        rows = project.run_sql("select answer from {schema}.view_model", fetch="all")
+        assert len(rows) == 1
+        assert rows[0][0] == 42
+
+
+class TestIncrementalMaterializationTransactionsOn(BaseTransactionsEnabled):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_model.sql": """
+{{ config(materialized='incremental', unique_key='id') }}
+select 1 as id, 'first' as value
+{% if is_incremental() %}
+union all
+select 2 as id, 'second' as value
+{% endif %}
+""",
+        }
+
+    def test_incremental_materialization(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        rows = project.run_sql(
+            "select count(*) as cnt from {schema}.incremental_model", fetch="one"
+        )
+        assert rows[0] == 1
+
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        rows = project.run_sql(
+            "select count(*) as cnt from {schema}.incremental_model", fetch="one"
+        )
+        assert rows[0] == 2
+
+
+class BaseFailingModelWithSideEffect:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "failing_model.sql": """
+{{ config(
+    materialized='table',
+    pre_hook=[
+        "INSERT INTO {{ this.schema }}.audit_log "
+        "(msg, created_at) VALUES ('from_model', getdate())"
+    ]
+) }}
+select 1/0 as boom
+""",
+        }
+
+
+class TestRollbackWithoutFlag(BaseFailingModelWithSideEffect):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"dbt_sqlserver_use_dbt_transactions": False}}
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Without transactions flag, DML in pre-hooks is auto-committed and not rolled back,"
+        " remove after migration to always use transactions.",
+    )
+    def test_side_effect_rolled_back(self, project):
+        project.run_sql("CREATE TABLE {schema}.audit_log (msg varchar(100), created_at datetime)")
+        run_dbt(["run", "-m", "failing_model"], expect_pass=False)
+        rows = project.run_sql("SELECT COUNT(*) FROM {schema}.audit_log", fetch="one")
+        assert rows[0] == 0
+
+
+class TestRollbackWithFlag(BaseFailingModelWithSideEffect):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"dbt_sqlserver_use_dbt_transactions": True}}
+
+    def test_side_effect_rolled_back(self, project):
+        project.run_sql("CREATE TABLE {schema}.audit_log (msg varchar(100), created_at datetime)")
+        run_dbt(["run", "-m", "failing_model"], expect_pass=False)
+        rows = project.run_sql("SELECT COUNT(*) FROM {schema}.audit_log", fetch="one")
+        assert rows[0] == 0
+
+
+class TestAfterCommitModelHookTransactionsOn(BaseTransactionsEnabled):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"dbt_sqlserver_use_dbt_transactions": True},
+            "models": {
+                "test": {
+                    "post-hook": [
+                        {"sql": "select 1", "transaction": False},
+                    ],
+                }
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"after_commit_hook_model.sql": "select 1 as id"}
+
+    def test_after_commit_post_hook_does_not_double_commit(self, project):
+        run_dbt()
+
+
+class TestFailedModelThenSuccessTransactionsOn(BaseTransactionsEnabled):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "good_model.sql": """
+{{ config(materialized='table') }}
+select 1 as id
+""",
+            "bad_model.sql": """
+{{ config(materialized='table') }}
+select 1/0 as boom
+""",
+        }
+
+    def test_failed_then_successful_run(self, project):
+        results = run_dbt(["run", "-m", "bad_model"], expect_pass=False)
+        assert len(results) == 1
+        assert results[0].status == "error"
+
+        results = run_dbt(["run", "-m", "good_model"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        rows = project.run_sql("select id from {schema}.good_model", fetch="all")
+        assert len(rows) == 1
+        assert rows[0][0] == 1

--- a/tests/unit/adapters/mssql/test_sqlserver_connection_manager.py
+++ b/tests/unit/adapters/mssql/test_sqlserver_connection_manager.py
@@ -2,7 +2,7 @@ import builtins
 import importlib
 from types import SimpleNamespace
 from typing import Any, Dict, List
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from azure.identity import AzureCliCredential
@@ -1460,3 +1460,137 @@ def test_open_with_pyodbc_backend_enables_driver_pooling(
     assert captured["autocommit"] is True
     assert captured["timeout"] == credentials.login_timeout
     assert "Pooling=true" in captured["connection_string"]
+
+
+@pytest.mark.parametrize("flag_value", [True, False])
+def test_add_begin_query_respects_dbt_sqlserver_use_dbt_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+    flag_value: bool,
+) -> None:
+    manager = object.__new__(SQLServerConnectionManager)
+    manager._dbt_sqlserver_use_dbt_transactions = flag_value
+
+    add_query_calls: list[tuple[str, bool]] = []
+
+    def fake_add_query(sql, auto_begin=True):
+        add_query_calls.append((sql, auto_begin))
+        return None, None
+
+    monkeypatch.setattr(manager, "add_query", fake_add_query)
+
+    result = manager.add_begin_query()
+
+    if flag_value:
+        assert add_query_calls == [("BEGIN TRANSACTION", False)]
+        assert result == (None, None)
+    else:
+        assert result is None
+        assert add_query_calls == []
+
+
+@pytest.mark.parametrize("flag_value", [True, False])
+def test_add_commit_query_respects_dbt_sqlserver_use_dbt_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+    flag_value: bool,
+) -> None:
+    manager = object.__new__(SQLServerConnectionManager)
+    manager._dbt_sqlserver_use_dbt_transactions = flag_value
+
+    add_query_calls: list[tuple[str, bool]] = []
+
+    def fake_add_query(sql, auto_begin=True):
+        add_query_calls.append((sql, auto_begin))
+        return None, None
+
+    monkeypatch.setattr(manager, "add_query", fake_add_query)
+
+    result = manager.add_commit_query()
+
+    if flag_value:
+        assert add_query_calls == [("IF @@TRANCOUNT > 0 COMMIT TRANSACTION", False)]
+        assert result == (None, None)
+    else:
+        assert result is None
+        assert add_query_calls == []
+
+
+def test_rollback_handle_enabled_executes_tsql_rollback(monkeypatch: pytest.MonkeyPatch) -> None:
+    handle = MagicMock()
+    connection = MagicMock(spec=Connection, handle=handle)
+    connection.name = "test_conn"
+
+    monkeypatch.setattr(
+        SQLServerConnectionManager,
+        "_dbt_sqlserver_use_dbt_transactions",
+        True,
+    )
+
+    SQLServerConnectionManager._rollback_handle(connection)
+
+    cursor = handle.cursor.return_value
+    cursor.execute.assert_called_once_with("IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION")
+    cursor.close.assert_called_once()
+    handle.rollback.assert_not_called()
+
+
+def test_rollback_handle_disabled_calls_handle_rollback(monkeypatch: pytest.MonkeyPatch) -> None:
+    handle = MagicMock()
+    connection = MagicMock(spec=Connection, handle=handle)
+    connection.name = "test_conn"
+
+    monkeypatch.setattr(
+        SQLServerConnectionManager,
+        "_dbt_sqlserver_use_dbt_transactions",
+        False,
+    )
+
+    SQLServerConnectionManager._rollback_handle(connection)
+
+    handle.rollback.assert_called_once()
+    handle.cursor.assert_not_called()
+
+
+def test_rollback_handle_enabled_exception_fires_rollback_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handle = MagicMock()
+    handle.cursor.side_effect = RuntimeError("connection lost")
+    connection = MagicMock(spec=Connection, handle=handle)
+    connection.name = "test_conn"
+
+    monkeypatch.setattr(
+        SQLServerConnectionManager,
+        "_dbt_sqlserver_use_dbt_transactions",
+        True,
+    )
+
+    with patch("dbt.adapters.sqlserver.sqlserver_connections.fire_event") as mock_fire_event:
+        SQLServerConnectionManager._rollback_handle(connection)
+
+    mock_fire_event.assert_called_once()
+    args, _ = mock_fire_event.call_args
+    fired_event = args[0]
+    from dbt.adapters.events.types import RollbackFailed
+
+    assert isinstance(fired_event, RollbackFailed)
+    assert fired_event.conn_name == "test_conn"
+
+
+def test_rollback_handle_disabled_exception_fires_rollback_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handle = MagicMock()
+    handle.rollback.side_effect = RuntimeError("rollback failed")
+    connection = MagicMock(spec=Connection, handle=handle)
+    connection.name = "test_conn"
+
+    monkeypatch.setattr(
+        SQLServerConnectionManager,
+        "_dbt_sqlserver_use_dbt_transactions",
+        False,
+    )
+
+    with patch("dbt.adapters.sqlserver.sqlserver_connections.fire_event") as mock_fire_event:
+        SQLServerConnectionManager._rollback_handle(connection)
+
+    mock_fire_event.assert_called_once()


### PR DESCRIPTION
Adds an opt-in flag that makes dbt's transaction hooks real at the SQL Server level, replacing the current no-op behavior, couldn't find the exact reason this was removed and this stopsome issues we currently have with left over temp tables, dirty reads of empty tables, non-standard behaviors.

### What it does

When `dbt_sqlserver_use_dbt_transactions: true` is set in `dbt_project.yml`:

- **`add_begin_query()`** emits `BEGIN TRANSACTION` instead of being a no-op
- **`add_commit_query()`** emits `IF @@TRANCOUNT > 0 COMMIT TRANSACTION` instead of being a no-op
- **`_rollback_handle()`** emits `IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION` with error handling matching the base class pattern (fires `RollbackFailed` event on failure)
- **After-commit hooks** — the run_hooks macro uses the flag to decide whether hooks run after a real commit or after the previous autocommit-based cleanup

When `false` (default), behavior is unchanged — `begin`/`commit` remain no-ops and each statement is auto-committed by the ODBC driver.

### Why opt-in

Enabling real transactions changes the atomicity guarantees and maps to default dbt standard behavior. Without the flag, each SQL statement commits individually — a failure mid-materialization doesn't roll back earlier DDL/DML. With the flag, the entire model run is wrapped in a single T-SQL transaction, and failures roll back everything.

This includes the DML refresh materialization (`table_dml_refresh.sql`), which has its own explicit `BEGIN TRANSACTION` for the atomic DELETE+INSERT swap. With the flag on, this nests inside dbt's outer transaction. SQL Server handles this correctly — only the outermost COMMIT actually commits, and a rollback always rolls back all nesting levels — so scratch tables from a partially-executed materialization are cleaned up on failure.

### Other changes

- Updated the stale comment in `table_dml_refresh.sql` to reflect the flag
- Fixed a line length issue in test files
- Added functional tests for table/view/incremental materializations, rollback behavior (with and without the flag), after-commit post-hooks, and recovery after a failed model including xfail temporal variants that will never pass without the flag.
- Added unit tests for `add_begin_query`/`add_commit_query` flag gating

Closes #708