### PR TITLE
Quick-win fixes: badge, exception type, is_integer, CI matrix, dead code

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,7 +13,7 @@ jobs:
   publish-docker-client:
     strategy:
       matrix:
-        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.10", "3.11", "3.12", "3.13"]
         docker_target: ["msodbc17", "msodbc18", "mssql"]
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ The same setting is also honoured via `vars:` for backwards compatibility; the b
 
 [![Unit tests](https://github.com/dbt-msft/dbt-sqlserver/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/dbt-msft/dbt-sqlserver/actions/workflows/unit-tests.yml)
 [![Integration tests on SQL Server](https://github.com/dbt-msft/dbt-sqlserver/actions/workflows/integration-tests-sqlserver.yml/badge.svg)](https://github.com/dbt-msft/dbt-sqlserver/actions/workflows/integration-tests-sqlserver.yml)
-[![Integration tests on Azure](https://github.com/dbt-msft/dbt-sqlserver/actions/workflows/integration-tests-azure.yml/badge.svg)](https://github.com/dbt-msft/dbt-sqlserver/actions/workflows/integration-tests-azure.yml)
 
 This adapter is community-maintained.
 You are welcome to contribute by creating issues, opening or reviewing pull requests, or helping other users in the Slack channel.

--- a/dbt/adapters/sqlserver/sqlserver_auth.py
+++ b/dbt/adapters/sqlserver/sqlserver_auth.py
@@ -11,6 +11,8 @@ import time
 from itertools import chain, repeat
 from typing import TYPE_CHECKING, Any, Callable, Dict, Mapping, Optional, cast
 
+import dbt_common.exceptions
+
 from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.sqlserver.sqlserver_constants import (
     AAD_TOKEN_AUTHENTICATIONS,
@@ -292,11 +294,9 @@ def get_pyodbc_attrs_before_credentials(credentials: SQLServerCredentials) -> Di
 
     if authentication == "activedirectoryaccesstoken":
         if credentials.access_token is None or credentials.access_token_expires_on is None:
-            raise ValueError(
-                (
-                    "Access token and a non-zero access token expiry epoch timestamp are "
-                    "required for ActiveDirectoryAccessToken authentication."
-                )
+            raise dbt_common.exceptions.DbtRuntimeError(
+                "Access token and a non-zero access token expiry epoch timestamp are "
+                "required for ActiveDirectoryAccessToken authentication."
             )
 
         if credentials.access_token_expires_on == 0:

--- a/dbt/include/sqlserver/macros/materializations/models/table/clone.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/table/clone.sql
@@ -1,4 +1,0 @@
-{% macro sqlserver__create_or_replace_clone(target_relation, defer_relation) %}
-    CREATE TABLE {{target_relation}}
-    AS CLONE OF {{defer_relation}}
-{% endmacro %}

--- a/dbt/include/sqlserver/macros/relations/views/create.sql
+++ b/dbt/include/sqlserver/macros/relations/views/create.sql
@@ -16,9 +16,6 @@
         CREATE OR ALTER VIEW {{ relation.include(database=False) }} AS {{ sql }};
     {% endset %}
 
-    {% set tst %}
-    SELECT '1' as col
-    {% endset %}
     USE [{{ relation.database }}];
     EXEC('{{- escape_single_quotes(query) -}}')
 

--- a/tests/unit/adapters/mssql/test_sqlserver_connection_manager.py
+++ b/tests/unit/adapters/mssql/test_sqlserver_connection_manager.py
@@ -118,7 +118,7 @@ def test_get_pyodbc_attrs_before_active_directory_access_token_requires_expiry(
     credentials.access_token = "some-token"
 
     credentials.access_token_expires_on = None
-    with pytest.raises(ValueError, match="access token expiry"):
+    with pytest.raises(DbtRuntimeError, match="access token expiry"):
         get_pyodbc_attrs_before_credentials(credentials)
 
 


### PR DESCRIPTION
## Summary

Four small, independent fixes surfaced by a repo audit. Each is its own commit, so they can be reviewed individually. They are intentionally removal-heavy and low-risk: the only behavioral change is #2, whose existing unit test is updated to match.

> An earlier `is_integer()` cleanup (add `tinyint`, drop dead Postgres aliases) was dropped from this PR. #702 already adds `tinyint` to `is_integer()`, so that work belongs there to avoid a conflict. See the note on #702 about also dropping the dead aliases.

Branch validation (whole branch, on top of current `master`): `ruff` clean, `black --check` clean, `mypy` reports 0 errors, and `pytest tests/unit` -> 110 passed.

### 1. Remove broken "Integration tests on Azure" badge (`docs`)

`README.md` rendered a status badge pointing at `integration-tests-azure.yml`, but no such workflow exists under `.github/workflows/` (only `unit-tests`, `integration-tests-sqlserver`, `publish-docker`, and `release-version`). The badge was therefore permanently broken. Removed that one badge line; the unit-test and SQL Server integration badges are unchanged.

### 2. Raise `DbtRuntimeError` instead of bare `ValueError` for a missing access token (`fix`)

In `sqlserver_auth.py`, the `ActiveDirectoryAccessToken` path raised a bare `ValueError` when `access_token` / `access_token_expires_on` were missing. Every other configuration fault in this layer raises `dbt_common.exceptions.DbtRuntimeError`, so this one escaped as an unclassified exception. It now raises `DbtRuntimeError` (message unchanged). The existing unit test that asserted `ValueError` is updated to expect `DbtRuntimeError`.

### 3. Drop Python 3.9 from the `publish-docker` matrix (`ci`)

`requires-python` is `>=3.10`, and the unit / integration / release workflows all target 3.10 to 3.13, but `publish-docker.yml` still built `CI-3.9-*` client images. Those images are not consumed by any workflow. Removed `"3.9"` from the matrix.

### 4. Remove dead clone macro and unused view scaffolding variable (`chore`)

- `materializations/models/table/clone.sql` defined `sqlserver__create_or_replace_clone`, which emits invalid T-SQL (`CREATE TABLE ... AS CLONE OF ...`). It is unreachable: `sqlserver__can_clone_table()` returns `False`, so dbt-core's clone materialization never dispatches to it, and `default__create_or_replace_clone` exists as the fallback regardless. Deleted the file. `sqlserver__can_clone_table()` (in `relations/table/clone.sql`) is left untouched.
- `relations/views/create.sql` contained a `{% set tst %}SELECT '1' as col{% endset %}` block that was never referenced. Removed.
