### PR TITLE
docs: correct stale version, release, and CI references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,6 @@ All CI/CD pipelines are using GitHub Actions. The following pipelines are availa
 
 * `publish-docker`: publishes the image we use in all other pipelines.
 * `unit-tests`: runs the unit tests for each supported Python version.
-* `integration-tests-azure`: runs the integration tests for Azure SQL Server.
 * `integration-tests-sqlserver`: runs the integration tests for SQL Server.
 * `release-version`: publishes the adapter to PyPI.
 
@@ -128,7 +127,7 @@ The following environment variables are available:
 
 ## Releasing a new version
 
-Make sure the version number is bumped in `__version__.py`. Then, create a git tag named `v<version>` and push it to GitHub.
-A GitHub Actions workflow will be triggered to build the package and push it to PyPI. 
+Make sure the version number is bumped in `dbt/adapters/sqlserver/__version__.py`. Then publish a GitHub Release with a tag named `v<version>`.
+A GitHub Actions workflow will be triggered to build the package and push it to PyPI.
 
-If you're releasing support for a new version of `dbt-core`, also bump the `dbt_version` in `setup.py`.
+If you're releasing support for a new version of `dbt-core`, also bump the `dbt-core` constraint in `dependencies` in `pyproject.toml`.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [dbt](https://www.getdbt.com) adapter for Microsoft SQL Server and Azure SQL services.
 
-The adapter supports dbt-core 0.14 or newer and follows the same versioning scheme.
-E.g. version 1.1.x of the adapter will be compatible with dbt-core 1.1.x.
+The adapter supports dbt-core 1.10 or newer and follows the same versioning scheme.
+E.g. version 1.10.x of the adapter is compatible with dbt-core 1.10.x.
 
 The minimum supported SQL Server version is SQL Server 2017.
 


### PR DESCRIPTION
## What

Corrects documentation that no longer matches the codebase. Docs only, no code or behavior changes.

**README.md**
- The adapter requires dbt-core 1.10 or newer, not 0.14. The dependency is pinned `dbt-core>=1.10.0,<2.0` in `pyproject.toml`, so the old "0.14 or newer" line was misleading for anyone checking compatibility.
- Updated the versioning-scheme example from `1.1.x` to `1.10.x` so it reflects a currently shipping line.

**CONTRIBUTING.md**
- Removed `integration-tests-azure` from the list of CI/CD pipelines. No such workflow exists under `.github/workflows/` (the only workflows are `publish-docker`, `unit-tests`, `integration-tests-sqlserver`, and `release-version`).
- Fixed the release instructions: the version lives at `dbt/adapters/sqlserver/__version__.py`, and `release-version.yml` triggers on a published GitHub Release (`on: release: types: [published]`), not on pushing a bare git tag.
- Pointed the dbt-core version bump at the `dependencies` array in `pyproject.toml`. The old text referenced `dbt_version` in `setup.py`, but there is no `setup.py` in this project.

## What was intentionally left alone

The `### Azure integration tests` section and its `DBT_AZURE*` environment variables remain, because those variables are still consumed by `tests/conftest.py` and `devops/scripts/wakeup_azure.py`. Azure testing is still supported even though there is no dedicated CI workflow named for it.

## Verification

- Each claim checked against the current tree: the pyproject pin, the `__version__.py` path, the absence of `setup.py`, the `release-version.yml` trigger, and the set of workflow files.
- Confirmed no remaining stale `0.14`, `dbt_version`, or `setup.py` references in either file.
- No trailing-whitespace or end-of-file issues, so the pre-commit hooks pass without auto-fixes.
