### PR TITLE
fix: honor configured query retries and correct the retry debug event

### DIFF
--- a/dbt/adapters/sqlserver/sqlserver_connections.py
+++ b/dbt/adapters/sqlserver/sqlserver_connections.py
@@ -224,8 +224,12 @@ class SQLServerConnectionManager(SQLConnectionManager):
                     raise e
 
                 fire_event(
+                    # NB: the field is ``base_msg`` (as in dbt-core's base
+                    # ``add_query``); ``message=`` raises a protobuf ParseError
+                    # at event construction, which previously crashed the first
+                    # retry instead of retrying.
                     AdapterEventDebug(
-                        message=(
+                        base_msg=(
                             f"Got a retryable error {type(e)}. {retry_limit - attempt} "
                             "retries left. Retrying in 1 second.\n"
                             f"Error:\n{e}"
@@ -277,7 +281,13 @@ class SQLServerConnectionManager(SQLConnectionManager):
                 sql=sql,
                 bindings=bindings,
                 retryable_exceptions=retryable_exceptions,
-                retry_limit=(credentials.retries if credentials.retries > 3 else retry_limit),
+                # The connection's configured ``retries`` is authoritative for
+                # query retries, mirroring ``open()`` which passes
+                # ``credentials.retries`` to ``retry_connection``. A previous
+                # ``credentials.retries > 3`` guard silently ignored configured
+                # values of 1-3 and used the hardcoded ``retry_limit`` of 2, so
+                # even the default ``retries: 3`` only attempted a query twice.
+                retry_limit=credentials.retries,
                 attempt=1,
             )
 

--- a/dbt/adapters/sqlserver/sqlserver_connections.py
+++ b/dbt/adapters/sqlserver/sqlserver_connections.py
@@ -224,10 +224,6 @@ class SQLServerConnectionManager(SQLConnectionManager):
                     raise e
 
                 fire_event(
-                    # NB: the field is ``base_msg`` (as in dbt-core's base
-                    # ``add_query``); ``message=`` raises a protobuf ParseError
-                    # at event construction, which previously crashed the first
-                    # retry instead of retrying.
                     AdapterEventDebug(
                         base_msg=(
                             f"Got a retryable error {type(e)}. {retry_limit - attempt} "
@@ -281,12 +277,8 @@ class SQLServerConnectionManager(SQLConnectionManager):
                 sql=sql,
                 bindings=bindings,
                 retryable_exceptions=retryable_exceptions,
-                # The connection's configured ``retries`` is authoritative for
-                # query retries, mirroring ``open()`` which passes
-                # ``credentials.retries`` to ``retry_connection``. A previous
-                # ``credentials.retries > 3`` guard silently ignored configured
-                # values of 1-3 and used the hardcoded ``retry_limit`` of 2, so
-                # even the default ``retries: 3`` only attempted a query twice.
+                # ``retries`` caps total execute attempts, so ``retries: 1``
+                # means a single attempt with no retry.
                 retry_limit=credentials.retries,
                 attempt=1,
             )

--- a/tests/unit/adapters/mssql/test_sqlserver_connection_manager.py
+++ b/tests/unit/adapters/mssql/test_sqlserver_connection_manager.py
@@ -1642,13 +1642,13 @@ def _make_add_query_manager(
 
     monkeypatch.setattr(manager, "exception_handler", _passthrough_exception_handler)
 
-    return manager, connection, cursor
+    return manager, cursor
 
 
 def test_add_query_retries_retryable_errors_until_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    manager, _connection, cursor = _make_add_query_manager(
+    manager, cursor = _make_add_query_manager(
         monkeypatch,
         retries=3,
         execute_side_effect=[_FakeRetryableError(), _FakeRetryableError(), None],
@@ -1667,68 +1667,55 @@ def test_add_query_retries_retryable_errors_until_success(
     assert mock_sleep.call_count == 2
 
 
-def test_add_query_honors_configured_retries_over_method_default(
+@pytest.mark.parametrize(
+    ("retries", "execute_side_effect", "expected_exception", "expected_attempts"),
+    [
+        pytest.param(
+            3,
+            _FakeRetryableError(),
+            _FakeRetryableError,
+            3,
+            id="retryable-error-exhausts-attempt-cap",
+        ),
+        pytest.param(
+            1,
+            _FakeRetryableError(),
+            _FakeRetryableError,
+            1,
+            id="retries-one-means-single-attempt",
+        ),
+        pytest.param(
+            3,
+            ValueError("not retryable"),
+            ValueError,
+            1,
+            id="non-retryable-error-not-retried",
+        ),
+    ],
+)
+def test_add_query_raises_after_expected_attempts(
     monkeypatch: pytest.MonkeyPatch,
+    retries: int,
+    execute_side_effect: Exception,
+    expected_exception: type,
+    expected_attempts: int,
 ) -> None:
-    # Regression guard: a `credentials.retries > 3` branch used to ignore
-    # configured values of 1-3 and fall back to a hardcoded limit of 2, so the
-    # default `retries: 3` attempted a query only twice. It must now attempt
-    # the query three times before giving up.
-    manager, _connection, cursor = _make_add_query_manager(
+    # ``retries`` caps the total number of execute attempts: ``retries: 3``
+    # tries a persistently failing query three times, ``retries: 1`` never
+    # retries, and errors outside ``retryable_exceptions`` raise immediately.
+    manager, cursor = _make_add_query_manager(
         monkeypatch,
-        retries=3,
-        execute_side_effect=_FakeRetryableError(),
+        retries=retries,
+        execute_side_effect=execute_side_effect,
     )
 
     with (
         patch("dbt.adapters.sqlserver.sqlserver_connections.fire_event"),
         patch("dbt.adapters.sqlserver.sqlserver_connections.time.sleep"),
     ):
-        with pytest.raises(_FakeRetryableError):
+        with pytest.raises(expected_exception):
             manager.add_query(
                 "select 1", auto_begin=False, retryable_exceptions=(_FakeRetryableError,)
             )
 
-    assert cursor.execute.call_count == 3
-
-
-def test_add_query_does_not_retry_when_retries_is_one(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    manager, _connection, cursor = _make_add_query_manager(
-        monkeypatch,
-        retries=1,
-        execute_side_effect=_FakeRetryableError(),
-    )
-
-    with (
-        patch("dbt.adapters.sqlserver.sqlserver_connections.fire_event"),
-        patch("dbt.adapters.sqlserver.sqlserver_connections.time.sleep"),
-    ):
-        with pytest.raises(_FakeRetryableError):
-            manager.add_query(
-                "select 1", auto_begin=False, retryable_exceptions=(_FakeRetryableError,)
-            )
-
-    assert cursor.execute.call_count == 1
-
-
-def test_add_query_does_not_retry_non_retryable_errors(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    manager, _connection, cursor = _make_add_query_manager(
-        monkeypatch,
-        retries=3,
-        execute_side_effect=ValueError("not retryable"),
-    )
-
-    with (
-        patch("dbt.adapters.sqlserver.sqlserver_connections.fire_event"),
-        patch("dbt.adapters.sqlserver.sqlserver_connections.time.sleep"),
-    ):
-        with pytest.raises(ValueError):
-            manager.add_query(
-                "select 1", auto_begin=False, retryable_exceptions=(_FakeRetryableError,)
-            )
-
-    assert cursor.execute.call_count == 1
+    assert cursor.execute.call_count == expected_attempts

--- a/tests/unit/adapters/mssql/test_sqlserver_connection_manager.py
+++ b/tests/unit/adapters/mssql/test_sqlserver_connection_manager.py
@@ -1,5 +1,6 @@
 import builtins
 import importlib
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any, Dict, List
 from unittest.mock import MagicMock, patch
@@ -1594,3 +1595,140 @@ def test_rollback_handle_disabled_exception_fires_rollback_failed(
         SQLServerConnectionManager._rollback_handle(connection)
 
     mock_fire_event.assert_called_once()
+
+
+class _FakeRetryableError(Exception):
+    """Stand-in for a backend retryable exception in add_query retry tests."""
+
+
+def _make_add_query_manager(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    retries: int,
+    execute_side_effect: Any,
+):
+    """Build a manager + thread connection wired for add_query retry tests.
+
+    Uses ``object.__new__`` (the pattern used elsewhere in this module) so no
+    real connection pool is constructed; only the collaborators add_query
+    touches are stubbed.
+    """
+
+    manager = object.__new__(SQLServerConnectionManager)
+
+    cursor = MagicMock()
+    cursor.execute.side_effect = execute_side_effect
+    cursor.rowcount = 0
+
+    handle = MagicMock()
+    handle.cursor.return_value = cursor
+
+    credentials = MagicMock()
+    credentials.retries = retries
+
+    connection = MagicMock()
+    connection.handle = handle
+    connection.credentials = credentials
+    connection.transaction_open = True
+    connection.name = "retry-test"
+
+    monkeypatch.setattr(manager, "get_thread_connection", lambda: connection)
+
+    # Isolate the retry loop from error translation / connection release, which
+    # have their own tests and otherwise depend on global runtime state.
+    @contextmanager
+    def _passthrough_exception_handler(_sql):
+        yield
+
+    monkeypatch.setattr(manager, "exception_handler", _passthrough_exception_handler)
+
+    return manager, connection, cursor
+
+
+def test_add_query_retries_retryable_errors_until_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, _connection, cursor = _make_add_query_manager(
+        monkeypatch,
+        retries=3,
+        execute_side_effect=[_FakeRetryableError(), _FakeRetryableError(), None],
+    )
+
+    with (
+        patch("dbt.adapters.sqlserver.sqlserver_connections.fire_event"),
+        patch("dbt.adapters.sqlserver.sqlserver_connections.time.sleep") as mock_sleep,
+    ):
+        _conn, result_cursor = manager.add_query(
+            "select 1", auto_begin=False, retryable_exceptions=(_FakeRetryableError,)
+        )
+
+    assert cursor.execute.call_count == 3
+    assert result_cursor is cursor
+    assert mock_sleep.call_count == 2
+
+
+def test_add_query_honors_configured_retries_over_method_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression guard: a `credentials.retries > 3` branch used to ignore
+    # configured values of 1-3 and fall back to a hardcoded limit of 2, so the
+    # default `retries: 3` attempted a query only twice. It must now attempt
+    # the query three times before giving up.
+    manager, _connection, cursor = _make_add_query_manager(
+        monkeypatch,
+        retries=3,
+        execute_side_effect=_FakeRetryableError(),
+    )
+
+    with (
+        patch("dbt.adapters.sqlserver.sqlserver_connections.fire_event"),
+        patch("dbt.adapters.sqlserver.sqlserver_connections.time.sleep"),
+    ):
+        with pytest.raises(_FakeRetryableError):
+            manager.add_query(
+                "select 1", auto_begin=False, retryable_exceptions=(_FakeRetryableError,)
+            )
+
+    assert cursor.execute.call_count == 3
+
+
+def test_add_query_does_not_retry_when_retries_is_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, _connection, cursor = _make_add_query_manager(
+        monkeypatch,
+        retries=1,
+        execute_side_effect=_FakeRetryableError(),
+    )
+
+    with (
+        patch("dbt.adapters.sqlserver.sqlserver_connections.fire_event"),
+        patch("dbt.adapters.sqlserver.sqlserver_connections.time.sleep"),
+    ):
+        with pytest.raises(_FakeRetryableError):
+            manager.add_query(
+                "select 1", auto_begin=False, retryable_exceptions=(_FakeRetryableError,)
+            )
+
+    assert cursor.execute.call_count == 1
+
+
+def test_add_query_does_not_retry_non_retryable_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, _connection, cursor = _make_add_query_manager(
+        monkeypatch,
+        retries=3,
+        execute_side_effect=ValueError("not retryable"),
+    )
+
+    with (
+        patch("dbt.adapters.sqlserver.sqlserver_connections.fire_event"),
+        patch("dbt.adapters.sqlserver.sqlserver_connections.time.sleep"),
+    ):
+        with pytest.raises(ValueError):
+            manager.add_query(
+                "select 1", auto_begin=False, retryable_exceptions=(_FakeRetryableError,)
+            )
+
+    assert cursor.execute.call_count == 1


### PR DESCRIPTION
## What

Fixes two defects in the query-level retry path in `SQLServerConnectionManager.add_query`.

**1. The retry-debug event was constructed with a nonexistent field.** On a retryable error, the code fired `AdapterEventDebug(message=...)`, but the event's field is `base_msg`. Construction does not crash: dbt-common logs an "Unable to parse logging event dictionary" warning and emits the event with an empty message (verified by constructing the event against the pinned dbt-adapters/dbt-common in this repo's environment). The retry itself still ran, but the debug line that should report the error and remaining attempts was blank. This now uses `base_msg=`, matching dbt-core's base `add_query`, which is where this method was originally copied from.

**2. Configured retry counts of 1-3 were silently ignored.** The retry limit was computed as `credentials.retries if credentials.retries > 3 else retry_limit`, where `retry_limit` is a hardcoded 2. Any configured `retries` value of 1, 2, or 3 was discarded in favor of 2, so even the default `retries: 3` capped a query at two attempts. The configured value is now passed through directly.

## Semantics

For queries, `retries` caps the **total number of execute attempts**, matching the base `SQLConnectionManager.add_query` contract (`attempt >= retry_limit`): `retries: 3` means up to three attempts (two retries), and `retries: 1` means a single attempt with no retry. Note this differs from connection opening, where `retry_connection` treats the same profile value as a retry count (`retries: 3` allows up to four connect attempts). That inconsistency exists upstream between `add_query` and `retry_connection` in dbt-adapters; this PR standardizes query behavior on the base `add_query` semantics and documents it in the code.

## Scope note

No in-tree caller currently passes `retryable_exceptions` to `add_query`: `execute()` calls `self.add_query(sql, auto_begin)`, and the backend retryable-exception tuples (`get_pyodbc_retryable_exceptions` / `get_mssql_python_retryable_exceptions`) are only wired into `retry_connection` in `open()`. This PR therefore fixes the retry mechanism for callers that opt in, but does not by itself enable query retries on the standard execute path. Wiring the backend tuples into `execute()` is deliberately left as a follow-up, since auto-retrying arbitrary statements after e.g. a dropped connection can double-execute non-idempotent SQL and deserves its own discussion.

## Tests

Adds unit tests for `add_query`'s retry path:
- retry until success on a retryable error (asserts attempt count, returned cursor, and sleep count),
- a parametrized failure-path test covering the configured attempt cap (`retries: 3` attempts three times), `retries: 1` (single attempt, no retry), and non-retryable errors raising immediately with no retry.

## Verification

- Full unit suite: 272 passed.
- ruff, black (line-length 99, py310), and mypy all clean on the changed files.
