### PR TITLE
install dev group explicitly in setup_env

### DIFF
--- a/.devcontainer/setup_env.sh
+++ b/.devcontainer/setup_env.sh
@@ -21,6 +21,8 @@ command -v uv >/dev/null 2>&1 || pip install uv
 [ -d .venv ] || uv venv
 source .venv/bin/activate
 
-# Install both backend extras so the devcontainer can exercise either connection path.
-uv sync --all-extras
-pre-commit install
+# Install both backend extras so the devcontainer can exercise either connection path,
+# plus the dev dependency group (pre-commit, pytest, etc.). Groups are installed
+# explicitly rather than relying on uv's default-group behaviour, which varies by version.
+uv sync --all-extras --group dev
+uv run pre-commit install


### PR DESCRIPTION
### What

Install the dev dependency group explicitly during devcontainer setup instead of relying on uv's implicit default-group behaviour. resolve #747

### Changes

- uv sync --all-extras → uv sync --all-extras --group dev
- Run pre-commit install via uv run so it uses the synced environment
- Added a comment explaining why the group is named explicitly

### Why

uv's default-group behaviour varies by version, so --all-extras alone didn't reliably install the dev group. Naming it explicitly makes the devcontainer deterministic across uv versions, ensuring pre-commit, pytest, and other dev tooling are always available.