### PR TITLE
feat: full_refresh_build config with prebuilt in-place rebuild path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `prebuilt` trade-off, by design: during a rebuild the target is empty/loading with no backup copy; a failed rebuild leaves an empty or partial table (recovery: rerun with `--full-refresh`).
 - `prebuilt` drops the table before rebuilding, so `{{ this }}` self-references must be guarded by `{% if is_incremental() %}` (false during rebuilds); models with unguarded self-references must keep the default `heap_then_index`. The adapter detects an unguarded self-reference in the compiled SQL and fails the rebuild before anything is dropped.
 - Incremental full refreshes (both build methods) now mark the target with a `dbt_full_refresh_incomplete` extended property until they complete: a normal incremental run over a table whose last full refresh failed errors with instructions to rerun `--full-refresh`, instead of silently appending onto stale, empty or partial data. The `prebuilt` index config is also validated before the old table is dropped.
+- `prebuilt` is now robust to a stale relation cache. The in-place create drops any physical target via an `OBJECT_ID` guard before recreating it, so a build no longer fails with `Msg 2714` when a table exists in the database but is absent from dbt's cache (e.g. created by an orphaned/concurrent writer after the run's cache snapshot). The rebuilt relation is also registered back into dbt's cache (`cache_added`) so the cache stays in sync after a raw-SQL prebuilt create.
 
 ### v1.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### Unreleased
+
+#### Features
+
+- Add `full_refresh_build` model config: `prebuilt` rebuilds the table in place - drop the old table, recreate it empty with its clustered design (the `as_columnstore` CCI or the clustered index from `indexes`), then bulk-load via `INSERT WITH (TABLOCK)`. No intermediate copy or rename swap, so peak rebuild disk is ~1x instead of 2x plus the uncompressed-heap overshoot. Default `heap_then_index` is unchanged.
+- `prebuilt` applies only under `--full-refresh` and on first builds; normal runs keep the configured refresh (swap build, or DML delete+insert) so live tables stay in place and visible. Rowstore models without a clustered index in `indexes` load in place as a heap.
+- Under `--full-refresh`, `prebuilt` takes precedence over `table_refresh_method: dml`: a fully-logged whole-table DELETE+INSERT is the wrong tool for a rebuild, and preserving the table would also preserve a physical design the rebuild is meant to replace.
+- `prebuilt` trade-off, by design: during a rebuild the target is empty/loading with no backup copy; a failed rebuild leaves an empty or partial table (recovery: rerun with `--full-refresh`).
+- `prebuilt` drops the table before rebuilding, so `{{ this }}` self-references must be guarded by `{% if is_incremental() %}` (false during rebuilds); models with unguarded self-references must keep the default `heap_then_index`. The adapter detects an unguarded self-reference in the compiled SQL and fails the rebuild before anything is dropped.
+- Incremental full refreshes (both build methods) now mark the target with a `dbt_full_refresh_incomplete` extended property until they complete: a normal incremental run over a table whose last full refresh failed errors with instructions to rerun `--full-refresh`, instead of silently appending onto stale, empty or partial data. The `prebuilt` index config is also validated before the old table is dropped.
+
 ### v1.10.1
 
 #### Features

--- a/dbt/include/sqlserver/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/incremental/incremental.sql
@@ -35,6 +35,7 @@
     {% if config.get('full_refresh_build', 'heap_then_index') == 'prebuilt' %}
       {#- first build: load straight into the clustered design -#}
       {% set build_sql = sqlserver__create_table_as_prebuilt(target_relation, sql) %}
+      {% set prebuilt_cache_add = true %}
     {% else %}
       {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}
     {% endif %}
@@ -59,6 +60,7 @@
       {% endif %}
       {% do adapter.drop_relation(existing_relation) %}
       {% set build_sql = sqlserver__create_table_as_prebuilt(target_relation, sql) %}
+      {% set prebuilt_cache_add = true %}
     {% else %}
       {% set build_sql = get_create_table_as_sql(False, intermediate_relation, sql) %}
       {% if existing_relation.type == 'table' %}
@@ -108,6 +110,15 @@
       {% do adapter.rename_relation(target_relation, backup_relation) %}
       {% do adapter.rename_relation(intermediate_relation, target_relation) %}
       {% do to_drop.append(backup_relation) %}
+  {% endif %}
+
+  {% if prebuilt_cache_add %}
+      {#- the prebuilt path lands the table via raw SQL, not a cache-maintaining
+          adapter method (rename_relation/drop_relation), so register it here to
+          keep dbt's relation cache in sync with the database. On the
+          full-refresh branch this also re-adds the target that drop_relation
+          removed from the cache. -#}
+      {% do adapter.cache_added(target_relation) %}
   {% endif %}
 
   {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}

--- a/dbt/include/sqlserver/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/incremental/incremental.sql
@@ -32,11 +32,47 @@
   {% set to_drop = [] %}
 
   {% if existing_relation is none %}
+    {% if config.get('full_refresh_build', 'heap_then_index') == 'prebuilt' %}
+      {#- first build: load straight into the clustered design -#}
+      {% set build_sql = sqlserver__create_table_as_prebuilt(target_relation, sql) %}
+    {% else %}
       {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}
+    {% endif %}
   {% elif full_refresh_mode %}
+    {#- the target is marked as having a full refresh in flight (blocking
+        normal runs until one completes), but only AFTER anything that can
+        fail on config alone - a pure config error must not mark a healthy
+        table -#}
+    {% if config.get('full_refresh_build', 'heap_then_index') == 'prebuilt' and should_full_refresh() %}
+      {#- in-place full refresh: drop the existing table, rebuild the target
+          directly with no intermediate or swap (explicit --full-refresh
+          only; view->table conversions keep the default path) -#}
+      {% do sqlserver__assert_no_unguarded_self_reference(target_relation, sql) %}
+      {#- validate the index config BEFORE marking or dropping anything -#}
+      {% do adapter.validate_indexes(
+          config.get('indexes', default=[]),
+          config.get('as_columnstore', default=true),
+          config.get('drop_unmanaged_indexes', default=false)
+      ) %}
+      {% if existing_relation.type == 'table' %}
+        {% do sqlserver__mark_full_refresh_incomplete(existing_relation) %}
+      {% endif %}
+      {% do adapter.drop_relation(existing_relation) %}
+      {% set build_sql = sqlserver__create_table_as_prebuilt(target_relation, sql) %}
+    {% else %}
       {% set build_sql = get_create_table_as_sql(False, intermediate_relation, sql) %}
+      {% if existing_relation.type == 'table' %}
+        {% do sqlserver__mark_full_refresh_incomplete(existing_relation) %}
+      {% endif %}
       {% set need_swap = true %}
+    {% endif %}
   {% else %}
+
+    {#- refuse to append onto a table whose last full refresh never
+        completed -#}
+    {% if existing_relation.type == 'table' %}
+      {% do sqlserver__assert_no_incomplete_full_refresh(existing_relation) %}
+    {% endif %}
 
     {% do run_query(get_create_table_as_sql(True, temp_relation, sql)) %}
 

--- a/dbt/include/sqlserver/macros/materializations/models/table/table.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/table/table.sql
@@ -72,6 +72,12 @@
       {{ sqlserver__create_table_as_prebuilt(target_relation, sql) }}
     {%- endcall %}
 
+    {#- the prebuilt path lands the table via raw SQL, not a cache-maintaining
+        adapter method (rename_relation), and above it may have dropped the
+        existing relation from the cache; register the rebuilt target so dbt's
+        relation cache stays in sync with the database -#}
+    {% do adapter.cache_added(target_relation) %}
+
     {% do create_indexes(target_relation) %}
   {% else %}
     -- build model

--- a/dbt/include/sqlserver/macros/materializations/models/table/table.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/table/table.sql
@@ -24,8 +24,16 @@
       "Valid values are: 'rename' (default), 'dml'."
     ) }}
   {%- endif -%}
+  {%- set full_refresh_build = config.get('full_refresh_build', 'heap_then_index') -%}
+  {#- prebuilt owns the rebuild boundaries (--full-refresh, first build);
+      table_refresh_method governs the steady-state refreshes in between -#}
+  {%- set use_prebuilt = (
+    full_refresh_build == 'prebuilt'
+    and (should_full_refresh() or existing_relation is none)
+  ) -%}
   {%- set use_dml_refresh = (
     table_refresh_method == 'dml'
+    and not use_prebuilt
     and existing_relation is not none
     and existing_relation.type == 'table'
   ) -%}
@@ -41,6 +49,30 @@
 
   {% if use_dml_refresh %}
     {{ sqlserver__table_dml_refresh(target_relation, sql) }}
+  {% elif use_prebuilt %}
+    {#- in-place rebuild: drop the existing table, then build the target
+        directly with no intermediate or swap -#}
+    {% if existing_relation is not none %}
+      {% do sqlserver__assert_no_unguarded_self_reference(target_relation, sql) %}
+    {% endif %}
+    {#- validate the index config BEFORE dropping anything -#}
+    {% do adapter.validate_indexes(
+        config.get('indexes', default=[]),
+        config.get('as_columnstore', default=true),
+        config.get('drop_unmanaged_indexes', default=false)
+    ) %}
+    {% if existing_relation is not none %}
+      {% set existing_relation = load_cached_relation(existing_relation) %}
+      {% if existing_relation is not none %}
+        {{ adapter.drop_relation(existing_relation) }}
+      {% endif %}
+    {% endif %}
+
+    {% call statement('main') -%}
+      {{ sqlserver__create_table_as_prebuilt(target_relation, sql) }}
+    {%- endcall %}
+
+    {% do create_indexes(target_relation) %}
   {% else %}
     -- build model
     {% call statement('main') -%}

--- a/dbt/include/sqlserver/macros/relations/table/create.sql
+++ b/dbt/include/sqlserver/macros/relations/table/create.sql
@@ -1,5 +1,12 @@
 {% macro sqlserver__create_table_as(temporary, relation, sql) -%}
     {%- set query_label = get_query_options(parse_options=True) -%}
+    {%- set full_refresh_build = config.get('full_refresh_build', 'heap_then_index') -%}
+    {%- if full_refresh_build not in ['heap_then_index', 'prebuilt'] -%}
+      {{ exceptions.raise_compiler_error(
+        "Invalid full_refresh_build '" ~ full_refresh_build ~ "'. "
+        "Valid values are: 'heap_then_index' (default), 'prebuilt'."
+      ) }}
+    {%- endif -%}
     {%- set tmp_relation = relation.incorporate(path={"identifier": relation.identifier ~ '__dbt_tmp_vw'}, type='view') -%}
 
     {%- do adapter.drop_relation(tmp_relation) -%}
@@ -48,3 +55,140 @@
    {% endif %}
 
 {% endmacro %}
+
+
+{% macro sqlserver__create_table_as_prebuilt(relation, sql) -%}
+    {#-
+      In-place build for full_refresh_build=prebuilt: create the table empty
+      under its final name with its clustered design (the as_columnstore CCI
+      or the clustered entry from the indexes config), then bulk-load it via
+      INSERT WITH (TABLOCK). Callers drop any existing target first.
+      See the CHANGELOG for the trade-offs of this build mode.
+    -#}
+    {%- set query_label = get_query_options(parse_options=True) -%}
+    {%- set as_columnstore = config.get('as_columnstore', default=true) -%}
+    {%- set contract_config = config.get('contract') -%}
+    {%- set contract_enforced = contract_config.enforced -%}
+    {%- set tmp_relation = relation.incorporate(path={"identifier": relation.identifier ~ '__dbt_tmp_vw'}, type='view') -%}
+
+    {#- find the clustered entry (validate_indexes guarantees at most one);
+        without one the table loads in place as a heap -#}
+    {%- set prebuilt_ns = namespace(clustered_dict=none) -%}
+    {%- if not as_columnstore -%}
+        {%- for raw_index in config.get('indexes', default=[]) -%}
+            {%- set parsed = adapter.parse_index(raw_index) -%}
+            {%- if parsed and parsed.type == 'clustered' and prebuilt_ns.clustered_dict is none -%}
+                {%- set prebuilt_ns.clustered_dict = raw_index -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- set has_clustered_design = as_columnstore or prebuilt_ns.clustered_dict is not none -%}
+    {%- if has_clustered_design -%}
+        {{ log("Rebuilding " ~ relation ~ " in place with full_refresh_build=prebuilt", info=true) }}
+    {%- else -%}
+        {% do log("full_refresh_build=prebuilt on " ~ relation ~ " has no clustered index in the indexes config; loading in place as a heap") %}
+    {%- endif -%}
+
+    {%- do adapter.drop_relation(tmp_relation) -%}
+    USE [{{ relation.database }}];
+    {{ get_create_view_as_sql(tmp_relation, sql) }}
+
+    {% if contract_enforced %}
+        {%- set ddl_query -%}
+            CREATE TABLE {{ relation }}
+            {{ get_assert_columns_equivalent(sql)  }}
+            {{ build_columns_constraints(relation) }}
+        {%- endset -%}
+        EXEC('{{- escape_single_quotes(ddl_query) -}}')
+    {% else %}
+        EXEC('SELECT TOP 0 * INTO {{ relation }} FROM {{ tmp_relation }}')
+    {% endif %}
+
+    {# mark the rebuild in progress; removed atomically with the load below #}
+    EXEC sp_addextendedproperty @name = N'dbt_full_refresh_incomplete', @value = '1',
+        @level0type = N'SCHEMA', @level0name = N'{{ relation.schema }}',
+        @level1type = N'TABLE', @level1name = N'{{ relation.identifier }}'
+
+    {% if as_columnstore %}
+        {{ sqlserver__create_clustered_columnstore_index(relation) }}
+    {% elif prebuilt_ns.clustered_dict is not none %}
+        {{ sqlserver__get_create_index_sql(relation, prebuilt_ns.clustered_dict) }}
+    {% endif %}
+
+    {%- if contract_enforced -%}
+        {%- set listColumns -%}
+            {%- for column in model['columns'] -%}
+                {{ "["~column~"]" }}{{ ", " if not loop.last }}
+            {%- endfor -%}
+        {%- endset -%}
+        {%- set insert_statement -%}
+            INSERT INTO {{ relation }} WITH (TABLOCK) ({{ listColumns }})
+            SELECT {{ listColumns }} FROM {{ tmp_relation }} {{ query_label }}
+        {%- endset -%}
+    {%- else -%}
+        {%- set insert_statement -%}
+            INSERT INTO {{ relation }} WITH (TABLOCK)
+            SELECT * FROM {{ tmp_relation }} {{ query_label }}
+        {%- endset -%}
+    {%- endif %}
+    {#- load and unmark atomically: any failure rolls back and keeps the marker -#}
+    {%- set insert_query -%}
+        SET XACT_ABORT ON;
+        BEGIN TRANSACTION;
+        {{ insert_statement }};
+        EXEC sp_dropextendedproperty @name = N'dbt_full_refresh_incomplete',
+            @level0type = N'SCHEMA', @level0name = N'{{ relation.schema }}',
+            @level1type = N'TABLE', @level1name = N'{{ relation.identifier }}';
+        COMMIT TRANSACTION;
+    {%- endset %}
+    EXEC('{{- escape_single_quotes(insert_query) -}}')
+
+    EXEC('DROP VIEW IF EXISTS {{ tmp_relation.include(database=False) }}')
+
+{% endmacro %}
+
+
+{% macro sqlserver__mark_full_refresh_incomplete(relation) -%}
+    {#- mark a table as having a full refresh in flight; the marker rides the
+        object, so a successful swap (old table dropped) or in-place rebuild
+        (table dropped) clears it naturally -#}
+    {% do run_query(
+        "if not exists (select 1 from sys.extended_properties where major_id = OBJECT_ID('"
+        ~ relation.schema ~ "." ~ relation.identifier
+        ~ "') and name = 'dbt_full_refresh_incomplete')"
+        ~ " EXEC sp_addextendedproperty @name = N'dbt_full_refresh_incomplete', @value = '1',"
+        ~ " @level0type = N'SCHEMA', @level0name = N'" ~ relation.schema ~ "',"
+        ~ " @level1type = N'TABLE', @level1name = N'" ~ relation.identifier ~ "'"
+    ) %}
+{%- endmacro %}
+
+
+{% macro sqlserver__assert_no_incomplete_full_refresh(relation) -%}
+    {%- set marker = run_query(
+        "select count(*) as marker_count from sys.extended_properties where major_id = OBJECT_ID('"
+        ~ relation.schema ~ "." ~ relation.identifier
+        ~ "') and name = 'dbt_full_refresh_incomplete'"
+    ) -%}
+    {%- if marker.rows[0][0] > 0 -%}
+        {{ exceptions.raise_compiler_error(
+            "A previous full refresh of " ~ relation
+            ~ " did not complete; the table may be stale, empty or partially "
+            "loaded. Rerun with --full-refresh."
+        ) }}
+    {%- endif -%}
+{%- endmacro %}
+
+
+{% macro sqlserver__assert_no_unguarded_self_reference(relation, compiled_sql) -%}
+    {#- a self-reference that survives full-refresh compilation (where
+        is_incremental() is false) would run against a table prebuilt has
+        already dropped: fail fast while the data is intact -#}
+    {%- if relation.render() | lower in compiled_sql | lower -%}
+        {{ exceptions.raise_compiler_error(
+            "Model " ~ relation ~ " contains an unguarded self-reference "
+            "({{ this }}) and full_refresh_build=prebuilt drops the table "
+            "before rebuilding. Guard the reference with is_incremental(), "
+            "or keep the default heap_then_index."
+        ) }}
+    {%- endif -%}
+{%- endmacro %}

--- a/dbt/include/sqlserver/macros/relations/table/create.sql
+++ b/dbt/include/sqlserver/macros/relations/table/create.sql
@@ -62,7 +62,9 @@
       In-place build for full_refresh_build=prebuilt: create the table empty
       under its final name with its clustered design (the as_columnstore CCI
       or the clustered entry from the indexes config), then bulk-load it via
-      INSERT WITH (TABLOCK). Callers drop any existing target first.
+      INSERT WITH (TABLOCK). The create is idempotent: it drops any physical
+      target first (see the OBJECT_ID guard below), so it is safe even when
+      dbt's relation cache is stale.
       See the CHANGELOG for the trade-offs of this build mode.
     -#}
     {%- set query_label = get_query_options(parse_options=True) -%}
@@ -93,6 +95,13 @@
     USE [{{ relation.database }}];
     {{ get_create_view_as_sql(tmp_relation, sql) }}
 
+    {#- drop any physical target before the bare CREATE / SELECT ... INTO below.
+        OBJECT_ID reads the database directly, so this is robust to dbt's
+        relation cache being stale (reporting none while the table exists) -
+        which would otherwise collide with Msg 2714 (object already exists) -#}
+    IF OBJECT_ID('{{ escape_single_quotes(relation.schema) }}.{{ escape_single_quotes(relation.identifier) }}', 'U') IS NOT NULL
+        EXEC('DROP TABLE {{ relation }}');
+
     {% if contract_enforced %}
         {%- set ddl_query -%}
             CREATE TABLE {{ relation }}
@@ -106,8 +115,8 @@
 
     {# mark the rebuild in progress; removed atomically with the load below #}
     EXEC sp_addextendedproperty @name = N'dbt_full_refresh_incomplete', @value = '1',
-        @level0type = N'SCHEMA', @level0name = N'{{ relation.schema }}',
-        @level1type = N'TABLE', @level1name = N'{{ relation.identifier }}'
+        @level0type = N'SCHEMA', @level0name = N'{{ escape_single_quotes(relation.schema) }}',
+        @level1type = N'TABLE', @level1name = N'{{ escape_single_quotes(relation.identifier) }}'
 
     {% if as_columnstore %}
         {{ sqlserver__create_clustered_columnstore_index(relation) }}
@@ -137,8 +146,8 @@
         BEGIN TRANSACTION;
         {{ insert_statement }};
         EXEC sp_dropextendedproperty @name = N'dbt_full_refresh_incomplete',
-            @level0type = N'SCHEMA', @level0name = N'{{ relation.schema }}',
-            @level1type = N'TABLE', @level1name = N'{{ relation.identifier }}';
+            @level0type = N'SCHEMA', @level0name = N'{{ escape_single_quotes(relation.schema) }}',
+            @level1type = N'TABLE', @level1name = N'{{ escape_single_quotes(relation.identifier) }}';
         COMMIT TRANSACTION;
     {%- endset %}
     EXEC('{{- escape_single_quotes(insert_query) -}}')

--- a/tests/functional/adapter/mssql/test_full_refresh_build.py
+++ b/tests/functional/adapter/mssql/test_full_refresh_build.py
@@ -573,3 +573,87 @@ class TestFullRefreshBuildSelfReference:
 
         # no marker was set, so a normal run still works
         run_dbt(["run", "--models", "selfref_model"])
+
+
+# A pre_hook runs AFTER the materialization snapshots existing_relation from the
+# relation cache but BEFORE the prebuilt create - and it writes via raw SQL, so
+# the cache is never told. That leaves dbt believing existing_relation is none
+# while the physical table exists: exactly the drift an orphaned/concurrent
+# writer produces, reproduced deterministically. Without the idempotent
+# OBJECT_ID drop inside sqlserver__create_table_as_prebuilt, the bare
+# CREATE / SELECT ... INTO collides with Msg 2714 (object already exists).
+_cache_drift_pre_hook = (
+    "IF OBJECT_ID('{{ this.schema }}.{{ this.identifier }}', 'U') IS NULL "
+    "EXEC('CREATE TABLE {{ this }} (column_a int)')"
+)
+
+models__cache_drift_incremental_sql = (
+    """
+{{
+  config(
+    materialized = "incremental",
+    as_columnstore = False,
+    full_refresh_build = "prebuilt",
+    indexes = [{'columns': ['column_a'], 'type': 'clustered'}],
+    pre_hook = \""""
+    + _cache_drift_pre_hook
+    + """\"
+  )
+}}
+
+select 1 as column_a
+
+{% if is_incremental() %}
+    where column_a > (select max(column_a) from {{ this }})
+{% endif %}
+"""
+)
+
+models__cache_drift_table_sql = (
+    """
+{{
+  config(
+    materialized = "table",
+    as_columnstore = False,
+    full_refresh_build = "prebuilt",
+    indexes = [{'columns': ['column_a'], 'type': 'clustered'}],
+    pre_hook = \""""
+    + _cache_drift_pre_hook
+    + """\"
+  )
+}}
+
+select 1 as column_a
+"""
+)
+
+
+class TestFullRefreshBuildStaleCache:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "cache_drift_incr.sql": models__cache_drift_incremental_sql,
+            "cache_drift_table.sql": models__cache_drift_table_sql,
+        }
+
+    def test_incremental_prebuilt_survives_stale_cache_collision(self, project, unique_schema):
+        # the pre_hook creates the target as a plain heap while dbt's cache
+        # still reports none; the first-build prebuilt path must drop it and
+        # rebuild in place rather than fail with Msg 2714
+        run_dbt(["run", "--models", "cache_drift_incr"])
+        rows = project.run_sql(
+            f"select count(*) from {unique_schema}.cache_drift_incr", fetch="one"
+        )
+        assert rows[0] == 1
+        # the prebuilt clustered design won, not the pre_hook's heap
+        idx = get_rowstore_indexes(project, unique_schema, "cache_drift_incr")
+        assert set(idx) == {"CLUSTERED"}
+
+    def test_table_prebuilt_survives_stale_cache_collision(self, project, unique_schema):
+        run_dbt(["run", "--models", "cache_drift_table"])
+        rows = project.run_sql(
+            f"select count(*) from {unique_schema}.cache_drift_table", fetch="one"
+        )
+        assert rows[0] == 1
+        idx = get_rowstore_indexes(project, unique_schema, "cache_drift_table")
+        assert set(idx) == {"CLUSTERED"}

--- a/tests/functional/adapter/mssql/test_full_refresh_build.py
+++ b/tests/functional/adapter/mssql/test_full_refresh_build.py
@@ -1,0 +1,575 @@
+import pytest
+
+from dbt.tests.util import run_dbt, run_dbt_and_capture
+
+models__invalid_value_sql = """
+{{
+  config(
+    materialized = "table",
+    full_refresh_build = "bogus"
+  )
+}}
+
+select 1 as column_a
+
+"""
+
+
+class TestFullRefreshBuildInvalid:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"invalid_value.sql": models__invalid_value_sql}
+
+    def test_invalid_value(self, project):
+        _, output = run_dbt_and_capture(["run", "--models", "invalid_value"], expect_pass=False)
+        assert "Invalid full_refresh_build" in output
+        assert "bogus" in output
+        assert "heap_then_index" in output
+        assert "prebuilt" in output
+
+
+models__cci_prebuilt_sql = """
+{{
+  config(
+    materialized = "table",
+    full_refresh_build = "prebuilt"
+  )
+}}
+
+select *
+from (
+  select 1 as column_a, 2 as column_b
+  union all
+  select 3, 4
+) ordered_inner
+order by column_a
+offset 0 rows
+
+"""
+
+
+def get_cci_indexes(project, unique_schema, table_name):
+    sql = f"""
+    select i.[name], i.type_desc
+    from sys.indexes i
+    where i.object_id = OBJECT_ID('{unique_schema}.{table_name}')
+      and i.index_id > 0
+    """
+    return project.run_sql(sql, fetch="all")
+
+
+class TestFullRefreshBuildColumnstore:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"cci_prebuilt.sql": models__cci_prebuilt_sql}
+
+    def test_cci_prebuilt_lifecycle(self, project, unique_schema):
+        # tiny row counts land in delta rowgroups, so assert physical
+        # design rather than rowgroup state
+        _, output = run_dbt_and_capture(["run", "--models", "cci_prebuilt", "--full-refresh"])
+        assert "full_refresh_build=prebuilt" in output
+
+        indexes = get_cci_indexes(project, unique_schema, "cci_prebuilt")
+        assert len(indexes) == 1
+        assert indexes[0][1] == "CLUSTERED COLUMNSTORE"
+        assert "dbt_tmp" not in indexes[0][0]
+        first_name = indexes[0][0]
+
+        # data made it through the two-step load
+        rows = project.run_sql(f"select count(*) from {unique_schema}.cci_prebuilt", fetch="one")
+        assert rows[0] == 2
+
+        # second full refresh: one CCI, stable name, no leftovers
+        _, output = run_dbt_and_capture(["run", "--models", "cci_prebuilt", "--full-refresh"])
+        assert "full_refresh_build=prebuilt" in output
+        indexes = get_cci_indexes(project, unique_schema, "cci_prebuilt")
+        assert len(indexes) == 1
+        assert indexes[0][0] == first_name
+
+        # normal run: default swap build, no prebuilt
+        _, output = run_dbt_and_capture(["run", "--models", "cci_prebuilt"])
+        assert "full_refresh_build=prebuilt" not in output
+        assert len(get_cci_indexes(project, unique_schema, "cci_prebuilt")) == 1
+        leftovers = project.run_sql(
+            f"""select count(*) from sys.tables t
+                join sys.schemas s on s.schema_id = t.schema_id
+                where s.name = '{unique_schema}'
+                and (t.name like '%__dbt_tmp%' or t.name like '%__dbt_backup%')""",
+            fetch="one",
+        )
+        assert leftovers[0] == 0
+
+
+models__rowstore_prebuilt_sql = """
+{{
+  config(
+    materialized = "table",
+    as_columnstore = False,
+    full_refresh_build = "prebuilt",
+    indexes=[
+      {'columns': ['column_b'], 'type': 'clustered', 'data_compression': 'page'},
+      {'columns': ['column_a'], 'type': 'nonclustered'},
+    ]
+  )
+}}
+
+select 1 as column_a, 2 as column_b
+
+"""
+
+models__fallback_no_clustered_sql = """
+{{
+  config(
+    materialized = "table",
+    as_columnstore = False,
+    full_refresh_build = "prebuilt",
+    indexes=[
+      {'columns': ['column_a'], 'type': 'nonclustered'},
+    ]
+  )
+}}
+
+select 1 as column_a, 2 as column_b
+
+"""
+
+models__prebuilt_default_cci_clustered_sql = """
+{{
+  config(
+    materialized = "table",
+    full_refresh_build = "prebuilt",
+    indexes=[
+      {'columns': ['column_a'], 'type': 'clustered'},
+    ]
+  )
+}}
+
+select 1 as column_a
+
+"""
+
+
+def get_rowstore_indexes(project, unique_schema, table_name):
+    sql = f"""
+    select i.[name], i.type_desc, isnull(max(p.data_compression_desc), '') as compression
+    from sys.indexes i
+    left join sys.partitions p
+      on p.object_id = i.object_id and p.index_id = i.index_id
+    where i.object_id = OBJECT_ID('{unique_schema}.{table_name}')
+      and i.index_id > 0
+    group by i.[name], i.type_desc
+    """
+    return {row[1]: (row[0], row[2]) for row in project.run_sql(sql, fetch="all")}
+
+
+class TestFullRefreshBuildRowstore:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "rowstore_prebuilt.sql": models__rowstore_prebuilt_sql,
+            "fallback_no_clustered.sql": models__fallback_no_clustered_sql,
+            "prebuilt_default_cci_clustered.sql": models__prebuilt_default_cci_clustered_sql,
+        }
+
+    def test_rowstore_prebuilt(self, project, unique_schema):
+        _, output = run_dbt_and_capture(["run", "--models", "rowstore_prebuilt", "--full-refresh"])
+        assert "full_refresh_build=prebuilt" in output
+
+        by_type = get_rowstore_indexes(project, unique_schema, "rowstore_prebuilt")
+        assert set(by_type) == {"CLUSTERED", "NONCLUSTERED"}
+
+        clustered_name, clustered_compression = by_type["CLUSTERED"]
+        assert clustered_name.startswith("dbt_idx_")
+        # compress-on-insert
+        assert clustered_compression == "PAGE"
+        assert by_type["NONCLUSTERED"][0].startswith("dbt_idx_")
+
+        rows = project.run_sql(
+            f"select count(*) from {unique_schema}.rowstore_prebuilt", fetch="one"
+        )
+        assert rows[0] == 1
+
+        # Full-refresh rebuild: stable names, still exactly one clustered.
+        run_dbt(["run", "--models", "rowstore_prebuilt", "--full-refresh"])
+        second = get_rowstore_indexes(project, unique_schema, "rowstore_prebuilt")
+        assert second == by_type
+
+        # Normal run: default swap path, no prebuilt.
+        _, output = run_dbt_and_capture(["run", "--models", "rowstore_prebuilt"])
+        assert "full_refresh_build=prebuilt" not in output
+
+    def test_fallback_without_clustered(self, project, unique_schema):
+        # no clustered index: loads as a heap with no console warning
+        _, output = run_dbt_and_capture(
+            ["run", "--models", "fallback_no_clustered", "--full-refresh"]
+        )
+        # the heap-fallback trace is debug level: never on the console
+        assert "loading in place as a heap" not in output
+
+        by_type = get_rowstore_indexes(project, unique_schema, "fallback_no_clustered")
+        assert set(by_type) == {"NONCLUSTERED"}
+
+        # rerun: still quiet, still heap + NCI
+        _, output = run_dbt_and_capture(
+            ["run", "--models", "fallback_no_clustered", "--full-refresh"]
+        )
+        assert "loading in place as a heap" not in output
+
+    def test_prebuilt_clustered_with_default_columnstore_errors(self, project):
+        # as_columnstore defaults true: the existing cross-config validation
+        # must reject the clustered rowstore entry with guidance.
+        _, output = run_dbt_and_capture(
+            ["run", "--models", "prebuilt_default_cci_clustered"], expect_pass=False
+        )
+        assert "as_columnstore" in output
+
+
+models__incr_prebuilt_sql = """
+{{
+  config(
+    materialized = "incremental",
+    as_columnstore = False,
+    full_refresh_build = "prebuilt",
+    indexes=[
+      {'columns': ['column_a'], 'type': 'clustered'},
+    ]
+  )
+}}
+
+select *
+from (
+  select 1 as column_a, 2 as column_b
+) t
+
+{% if is_incremental() %}
+    where column_a > (select max(column_a) from {{this}})
+{% endif %}
+
+"""
+
+models__contract_prebuilt_sql = """
+{{
+  config(
+    materialized = "table",
+    as_columnstore = False,
+    full_refresh_build = "prebuilt",
+    contract = {"enforced": True},
+    indexes=[
+      {'columns': ['column_a'], 'type': 'clustered'},
+    ]
+  )
+}}
+
+select 1 as column_a, cast('x' as varchar(10)) as column_b
+
+"""
+
+models__contract_prebuilt_yml = """
+version: 2
+models:
+  - name: contract_prebuilt
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: column_a
+        data_type: int
+      - name: column_b
+        data_type: varchar(10)
+"""
+
+models__dml_prebuilt_sql = """
+{{
+  config(
+    materialized = "table",
+    as_columnstore = False,
+    table_refresh_method = "dml",
+    full_refresh_build = "prebuilt",
+    indexes=[
+      {'columns': ['column_a'], 'type': 'clustered'},
+    ]
+  )
+}}
+
+select 1 as column_a, 2 as column_b
+
+"""
+
+
+class TestFullRefreshBuildIncrementalAndContract:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incr_prebuilt.sql": models__incr_prebuilt_sql,
+            "contract_prebuilt.sql": models__contract_prebuilt_sql,
+            "contract_prebuilt.yml": models__contract_prebuilt_yml,
+            "dml_prebuilt.sql": models__dml_prebuilt_sql,
+        }
+
+    def test_incremental_lifecycle(self, project, unique_schema):
+        # first build: prebuilt applies (no existing table)
+        _, output = run_dbt_and_capture(["run", "--models", "incr_prebuilt"])
+        assert "full_refresh_build=prebuilt" in output
+        first = get_rowstore_indexes(project, unique_schema, "incr_prebuilt")
+        assert set(first) == {"CLUSTERED"}
+        assert first["CLUSTERED"][0].startswith("dbt_idx_")
+
+        # plain incremental run: no prebuilt
+        _, output = run_dbt_and_capture(["run", "--models", "incr_prebuilt"])
+        assert "full_refresh_build=prebuilt" not in output
+        assert get_rowstore_indexes(project, unique_schema, "incr_prebuilt") == first
+
+        # full refresh: prebuilt, stable index name
+        _, output = run_dbt_and_capture(["run", "--models", "incr_prebuilt", "--full-refresh"])
+        assert "full_refresh_build=prebuilt" in output
+        assert get_rowstore_indexes(project, unique_schema, "incr_prebuilt") == first
+
+    def test_contract_enforced_prebuilt(self, project, unique_schema):
+        _, output = run_dbt_and_capture(["run", "--models", "contract_prebuilt", "--full-refresh"])
+        assert "full_refresh_build=prebuilt" in output
+        by_type = get_rowstore_indexes(project, unique_schema, "contract_prebuilt")
+        assert set(by_type) == {"CLUSTERED"}
+        assert by_type["CLUSTERED"][0].startswith("dbt_idx_")
+
+        # stable on full-refresh rerun; normal run keeps the default path
+        run_dbt(["run", "--models", "contract_prebuilt", "--full-refresh"])
+        assert get_rowstore_indexes(project, unique_schema, "contract_prebuilt") == by_type
+        _, output = run_dbt_and_capture(["run", "--models", "contract_prebuilt"])
+        assert "full_refresh_build=prebuilt" not in output
+
+    def test_dml_refresh_prebuilt_on_rebuild_boundaries(self, project, unique_schema):
+        # first build: prebuilt applies (opted in, indices from birth);
+        # dml governs only the steady-state refreshes in between
+        _, output = run_dbt_and_capture(["run", "--models", "dml_prebuilt"])
+        assert "full_refresh_build=prebuilt" in output
+        _, output = run_dbt_and_capture(["run", "--models", "dml_prebuilt"])
+        assert "full_refresh_build=prebuilt" not in output
+        by_type = get_rowstore_indexes(project, unique_schema, "dml_prebuilt")
+        assert set(by_type) == {"CLUSTERED"}
+        first_name = by_type["CLUSTERED"][0]
+
+        # --full-refresh is a rebuild boundary: prebuilt wins over dml,
+        # the table is dropped and rebuilt in place (a fully-logged
+        # whole-table DELETE+INSERT is the wrong tool for a rebuild)
+        _, output = run_dbt_and_capture(["run", "--models", "dml_prebuilt", "--full-refresh"])
+        assert "full_refresh_build=prebuilt" in output
+        by_type = get_rowstore_indexes(project, unique_schema, "dml_prebuilt")
+        assert set(by_type) == {"CLUSTERED"}
+        assert by_type["CLUSTERED"][0] == first_name
+        rows = project.run_sql(f"select count(*) from {unique_schema}.dml_prebuilt", fetch="one")
+        assert rows[0] == 1
+
+
+models__guard_model_sql = """
+{{
+  config(
+    materialized = "incremental",
+    as_columnstore = False,
+    full_refresh_build = "prebuilt",
+    indexes = var('guard_indexes', [{'columns': ['column_a'], 'type': 'clustered'}])
+  )
+}}
+
+select *
+from (
+  select 1 as column_a, 2 as column_b
+) t
+
+{% if is_incremental() %}
+    where column_a > (select max(column_a) from {{this}})
+{% endif %}
+
+"""
+
+
+class TestFullRefreshBuildSafety:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"guard_model.sql": models__guard_model_sql}
+
+    def row_count(self, project, unique_schema):
+        return project.run_sql(f"select count(*) from {unique_schema}.guard_model", fetch="one")[0]
+
+    def test_invalid_config_validated_before_drop(self, project, unique_schema):
+        run_dbt(["run", "--models", "guard_model"])
+        # an out-of-band row the model cannot regenerate: proves the OLD
+        # table survived rather than being dropped and rebuilt
+        project.run_sql(f"insert into {unique_schema}.guard_model values (99, 99)")
+        assert self.row_count(project, unique_schema) == 2
+
+        # An invalid index set (two clustered entries) must fail BEFORE the
+        # old table is dropped.
+        bad = (
+            "[{'columns': ['column_a'], 'type': 'clustered'},"
+            " {'columns': ['column_b'], 'type': 'clustered'}]"
+        )
+        run_dbt_and_capture(
+            [
+                "run",
+                "--models",
+                "guard_model",
+                "--full-refresh",
+                "--vars",
+                f"guard_indexes: {bad}",
+            ],
+            expect_pass=False,
+        )
+        assert self.row_count(project, unique_schema) == 2
+
+    def test_failed_rebuild_blocks_normal_incremental_run(self, project, unique_schema):
+        run_dbt(["run", "--models", "guard_model"])
+
+        # Simulate a prebuilt rebuild that died mid-load: empty table carrying
+        # the in-progress marker.
+        project.run_sql(f"truncate table {unique_schema}.guard_model")
+        project.run_sql(f"""EXEC sp_addextendedproperty @name = N'dbt_full_refresh_incomplete',
+                @value = '1', @level0type = N'SCHEMA',
+                @level0name = '{unique_schema}',
+                @level1type = N'TABLE', @level1name = 'guard_model'""")
+
+        # A normal incremental run must ERROR, not silently append.
+        _, output = run_dbt_and_capture(["run", "--models", "guard_model"], expect_pass=False)
+        assert "did not complete" in output
+        assert "--full-refresh" in output
+
+        # --full-refresh recovers and clears the marker.
+        run_dbt(["run", "--models", "guard_model", "--full-refresh"])
+        assert self.row_count(project, unique_schema) == 1
+        marker = project.run_sql(
+            f"""select count(*) from sys.extended_properties
+                where major_id = OBJECT_ID('{unique_schema}.guard_model')
+                and name = 'dbt_full_refresh_incomplete'""",
+            fetch="one",
+        )
+        assert marker[0] == 0
+
+
+models__swap_guard_sql = """
+{{
+  config(
+    materialized = "incremental",
+    as_columnstore = False
+  )
+}}
+
+select 1 as column_a {% if var('break_model', false) %}, 1/0 as boom {% endif %}
+
+"""
+
+
+class TestFullRefreshBuildSwapGuard:
+    """The incomplete-rebuild marker also protects DEFAULT (swap) full
+    refreshes: a rebuild that dies mid-intermediate-build must block normal
+    incremental runs instead of silently appending onto the stale table."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "guard_model.sql": models__guard_model_sql,
+            "swap_guard.sql": models__swap_guard_sql,
+        }
+
+    def count(self, project, unique_schema, table):
+        return project.run_sql(f"select count(*) from {unique_schema}.{table}", fetch="one")[0]
+
+    def marker_count(self, project, unique_schema, table):
+        return project.run_sql(
+            f"""select count(*) from sys.extended_properties
+                where major_id = OBJECT_ID('{unique_schema}.{table}')
+                and name = 'dbt_full_refresh_incomplete'""",
+            fetch="one",
+        )[0]
+
+    def test_failed_swap_full_refresh_blocks_normal_runs(self, project, unique_schema):
+        run_dbt(["run", "--models", "swap_guard"])
+        project.run_sql(f"insert into {unique_schema}.swap_guard values (99)")
+        assert self.count(project, unique_schema, "swap_guard") == 2
+
+        # full refresh dies mid-intermediate-build (runtime divide-by-zero):
+        # old table stays live but is now marked incomplete
+        run_dbt_and_capture(
+            ["run", "--models", "swap_guard", "--full-refresh", "--vars", "break_model: true"],
+            expect_pass=False,
+        )
+        assert self.count(project, unique_schema, "swap_guard") == 2
+        assert self.marker_count(project, unique_schema, "swap_guard") == 1
+
+        # a normal run must ERROR, not append onto the stale table
+        _, output = run_dbt_and_capture(["run", "--models", "swap_guard"], expect_pass=False)
+        assert "did not complete" in output
+        assert self.count(project, unique_schema, "swap_guard") == 2
+
+        # a successful full refresh recovers; the marker leaves with the
+        # old table when it is swapped out
+        run_dbt(["run", "--models", "swap_guard", "--full-refresh"])
+        assert self.count(project, unique_schema, "swap_guard") == 1
+        assert self.marker_count(project, unique_schema, "swap_guard") == 0
+
+    def test_real_failure_during_prebuilt_rebuild_sets_marker(self, project, unique_schema):
+        run_dbt(["run", "--models", "guard_model"])
+
+        # an index on a column the model doesn't produce passes config
+        # validation but fails at the engine AFTER the drop: the marker on
+        # the new empty table must be present
+        bad = "[{'columns': ['no_such_column'], 'type': 'clustered'}]"
+        run_dbt_and_capture(
+            [
+                "run",
+                "--models",
+                "guard_model",
+                "--full-refresh",
+                "--vars",
+                f"guard_indexes: {bad}",
+            ],
+            expect_pass=False,
+        )
+        assert self.marker_count(project, unique_schema, "guard_model") == 1
+
+        _, output = run_dbt_and_capture(["run", "--models", "guard_model"], expect_pass=False)
+        assert "did not complete" in output
+
+        run_dbt(["run", "--models", "guard_model", "--full-refresh"])
+        assert self.count(project, unique_schema, "guard_model") == 1
+        assert self.marker_count(project, unique_schema, "guard_model") == 0
+
+
+models__selfref_model_sql = """
+{{
+  config(
+    materialized = "incremental",
+    as_columnstore = False,
+    full_refresh_build = "prebuilt",
+    indexes = [{'columns': ['column_a'], 'type': 'clustered'}]
+  )
+}}
+
+select 1 as column_a
+{% if var('selfref', false) %}
+union all
+select column_a from {{ this }} where 1 = 0
+{% endif %}
+
+"""
+
+
+class TestFullRefreshBuildSelfReference:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"selfref_model.sql": models__selfref_model_sql}
+
+    def test_unguarded_self_reference_fails_before_drop(self, project, unique_schema):
+        run_dbt(["run", "--models", "selfref_model"])
+        project.run_sql(f"insert into {unique_schema}.selfref_model values (99)")
+
+        # an unguarded {{ this }} must fail fast: BEFORE the drop (data
+        # intact) and BEFORE the marker (normal runs not poisoned)
+        _, output = run_dbt_and_capture(
+            ["run", "--models", "selfref_model", "--full-refresh", "--vars", "selfref: true"],
+            expect_pass=False,
+        )
+        assert "self-reference" in output
+        rows = project.run_sql(f"select count(*) from {unique_schema}.selfref_model", fetch="one")
+        assert rows[0] == 2
+
+        # no marker was set, so a normal run still works
+        run_dbt(["run", "--models", "selfref_model"])


### PR DESCRIPTION
Adds a full_refresh_build model config offering a lower-disk full-refresh rebuild path. Builds on the indexes feature shipped in v1.10.1. Resolve #749 

| value | behaviour |
| --- | --- |
| `heap_then_index` | **Default.** Load as heap, swap, then build clustered design. Unchanged. |
| `prebuilt` | Drop old table → recreate empty with final clustered design (CCI or clustered index) → `INSERT WITH (TABLOCK)`. No intermediate copy, no swap → ~1x peak disk instead of ~2x. |

### Behaviour

- Applies only under --full-refresh and on first builds; normal runs keep the configured refresh. Takes precedence over table_refresh_method: dml.
- Drops the table, so {{ this }} self-references must be guarded by {% if is_incremental() %}; the adapter detects an unguarded self-reference in the compiled SQL and fails before dropping anything.
- Trade-off: during a rebuild the target is empty/loading with no backup; a failure leaves an empty/partial table (recovery: rerun --full-refresh).
- Full refreshes mark the target with a dbt_full_refresh_incomplete extended property until they complete, so a later normal incremental over a failed refresh errors instead of appending onto stale data.

### Performance: parallel index build vs. serial insert (edition matters)

prebuilt swaps the default's post-load CREATE INDEX for an INSERT WITH (TABLOCK) into the existing index:

- Enterprise: the post-load index build is parallel, so prebuilt (serial insert) can be slower on large tables — you pay build time for the disk win.
- Non-Enterprise (Standard/Web/Express): the index build was serial anyway (parallel index ops are Enterprise-only), so prebuilt costs little/no extra time and is the clearer win.

The ~1x peak-disk benefit holds on every edition; only the time cost is edition-dependent.

### Testing

- tests/functional/adapter/mssql/test_full_refresh_build.py — 13 tests covering columnstore/rowstore/incremental/contract prebuilt paths, the self-reference guard, invalid-config-before-drop, and the incomplete-refresh marker.