### PR TITLE
fix: report rows affected for incremental delete+insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 #### Bugfixes
 
+- Fix `rows_affected` reporting zero for delete+insert incremental models by suppressing the DELETE row-count token before restoring `NOCOUNT` for the INSERT. [#583](https://github.com/dbt-msft/dbt-sqlserver/issues/583)
 - Fix unit tests with empty fixtures (`rows: []`) generating invalid `limit 0` syntax; emit `top 0` instead. Also fix `get_columns_in_query()` for queries starting with a CTE, which broke unit tests with an empty `expect` block; such queries are now described via `sp_describe_first_result_set` instead of being executed. [#698](https://github.com/dbt-msft/dbt-sqlserver/issues/698)
 - Fix catalog generation for NVARCHAR/NCHAR columns: use `user_type_id` instead of `system_type_id` in catalog.sql, preventing them from appearing as `SYSNAME` in `dbt docs`. [#637](https://github.com/dbt-msft/dbt-sqlserver/issues/637)
 - Fix `varchar(max)` / `nvarchar(max)` columns being incorrectly treated as size `-1` during type expansion, preventing `varchar(max)` → `varchar(100)` narrowing and properly allowing `varchar(100)` → `varchar(max)` expansion.

--- a/dbt/include/sqlserver/macros/materializations/models/incremental/merge.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/incremental/merge.sql
@@ -14,6 +14,7 @@
 
     {% if unique_key %}
         {% if unique_key is sequence and unique_key is not string %}
+            SET NOCOUNT ON;
             delete from {{ target }}
             where exists (
                 select null
@@ -30,7 +31,9 @@
                 {% endfor %}
             {% endif %}
             {{ query_label }}
+            SET NOCOUNT OFF;
         {% else %}
+            SET NOCOUNT ON;
             delete from {{ target }}
             where (
                 {{ unique_key }}) in (
@@ -43,6 +46,7 @@
                 {% endfor %}
             {%- endif -%}
             {{ query_label }}
+            SET NOCOUNT OFF;
         {% endif %}
     {% endif %}
 
@@ -71,6 +75,7 @@
     {% endif %}
     {% do arg_dict.update({'incremental_predicates': incremental_predicates}) %}
 
+    SET NOCOUNT ON;
     delete DBT_INTERNAL_TARGET from {{ target }} AS DBT_INTERNAL_TARGET
     where (
     {% for predicate in incremental_predicates %}
@@ -78,6 +83,7 @@
     {% endfor %}
     )
     {{ query_label }}
+    SET NOCOUNT OFF;
 
     {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
     insert into {{ target }} ({{ dest_cols_csv }})

--- a/tests/functional/adapter/mssql/test_query_options.py
+++ b/tests/functional/adapter/mssql/test_query_options.py
@@ -259,6 +259,7 @@ class TestQueryOptionsOnIncrementalDeleteInsert:
         results = run_dbt(["run"])
         assert len(results) == 1
         assert results[0].status == "success"
+        assert results[0].adapter_response["rows_affected"] == 3
 
         sql = _find_compiled_run_sql(project, "inc_model.sql")
         assert "MAXDOP 1" in sql


### PR DESCRIPTION
Fixes #583.

SQL Server can report the row count from the DELETE statement when a delete+insert incremental strategy is submitted as one batch. If no rows are deleted, dbt reports rows_affected=0 even when the INSERT adds rows.

This suppresses the DELETE row-count token with SET NOCOUNT ON, restores SET NOCOUNT OFF before the INSERT, and applies the same handling to microbatch incrementals.

The existing incremental delete+insert functional test now asserts rows_affected=3 on its second run.

Validation: 281 unit tests passed; Ruff and pre-commit checks passed; 27 functional tests collected.