### PR TITLE
fix: apply session-level SET XACT_ABORT ON to all connections

### DIFF
--- a/.github/workflows/integration-tests-sqlserver.yml
+++ b/.github/workflows/integration-tests-sqlserver.yml
@@ -125,7 +125,7 @@ jobs:
         run: uv pip install --system -e ".[$INSTALL_EXTRA]" --group dev
 
       - name: Run functional tests
-        run: pytest -ra -v tests/functional --profile "ci_sql_server"
+        run: pytest -n auto -ra -v tests/functional --profile "ci_sql_server"
         env:
           DBT_TEST_USER_1: DBT_TEST_USER_1
           DBT_TEST_USER_2: DBT_TEST_USER_2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Incremental full refreshes (both build methods) now mark the target with a `dbt_full_refresh_incomplete` extended property until they complete: a normal incremental run over a table whose last full refresh failed errors with instructions to rerun `--full-refresh`, instead of silently appending onto stale, empty or partial data. The `prebuilt` index config is also validated before the old table is dropped.
 - `prebuilt` is now robust to a stale relation cache. The in-place create drops any physical target via an `OBJECT_ID` guard before recreating it, so a build no longer fails with `Msg 2714` when a table exists in the database but is absent from dbt's cache (e.g. created by an orphaned/concurrent writer after the run's cache snapshot). The rebuilt relation is also registered back into dbt's cache (`cache_added`) so the cache stays in sync after a raw-SQL prebuilt create.
 
+#### Bugfixes
+
+- **Behavior change:** `SET XACT_ABORT ON` is now a session-level default on every connection the adapter opens, fixing silent, committed data loss on the DML table refresh path (and any other multi-statement batch): a mid-batch run-time error (e.g. a `NOT NULL`/constraint violation on the swap `INSERT`) previously aborted only the failing statement, not the batch, so a trailing `COMMIT` could still commit a partial result — most notably an emptied target after the `DELETE` succeeded and the `INSERT` failed. This is on by default in this already-published 1.11.x line; opt out per profile with `xact_abort: false` if you rely on continue-on-error batch semantics in custom hooks. [#718](https://github.com/dbt-msft/dbt-sqlserver/issues/718)
+
 ### v1.10.1
 
 #### Features

--- a/README.md
+++ b/README.md
@@ -171,6 +171,25 @@ flags:
   dbt_sqlserver_use_dbt_transactions: true # <-- opt-in; default is false
 ```
 
+### `xact_abort`
+
+*(default: `true`)* Profile/connection field. When enabled, the adapter runs `SET XACT_ABORT ON;` once per connection, right after it opens. With `XACT_ABORT ON`, a run-time error partway through a multi-statement batch (e.g. a `NOT NULL`/constraint violation during the DML table refresh's DELETE+INSERT swap) aborts the whole batch and rolls back any open transaction, instead of only aborting the failing statement and letting a trailing `COMMIT` persist a partial result. See [#718](https://github.com/dbt-msft/dbt-sqlserver/issues/718).
+
+This is independent of `dbt_sqlserver_use_dbt_transactions` above: that flag decides who owns the transaction boundary (dbt vs. the driver's autocommit), while `xact_abort` decides how the server reacts to a run-time error mid-batch. `XACT_ABORT ON` matters even when there is no explicit transaction at all, which is exactly the configuration `dbt_sqlserver_use_dbt_transactions` offers no protection in — so the two settings are not derived from one another and both need to be considered independently.
+
+Turn it off only if a project intentionally relies on continue-on-error batch semantics (e.g. a hook that expects one failing statement in a batch not to abort the rest):
+
+```yaml
+# profiles.yml
+your_profile:
+  target: dev
+  outputs:
+    dev:
+      type: sqlserver
+      # ...
+      xact_abort: false # <-- opt-out; default is true
+```
+
 ### `column_type_expansion_max_rows`
 
 *(default: `1000000`)* Per-model config that limits when safe type expansion runs. When the target table exceeds this row count, safe type expansion is skipped (basic same-family string resizes still proceed). Set to `-1` to disable the check entirely.

--- a/dbt/adapters/sqlserver/sqlserver_connections.py
+++ b/dbt/adapters/sqlserver/sqlserver_connections.py
@@ -65,6 +65,10 @@ logger = AdapterLogger("sqlserver")
 # Connection so cancel() can reach it from another thread. See cancel().
 _IN_FLIGHT_CURSOR_ATTR = "_dbt_sqlserver_in_flight_cursor"
 
+# Fires once per process (not per connection/thread) when xact_abort is
+# disabled. See SQLServerConnectionManager._warn_xact_abort_disabled_once.
+_xact_abort_warning_logged = False
+
 
 class SQLServerConnectionManager(SQLConnectionManager):
     TYPE = "sqlserver"
@@ -144,7 +148,65 @@ class SQLServerConnectionManager(SQLConnectionManager):
             retryable_exceptions=retryable_exceptions,
         )
 
+        if conn.state == ConnectionState.OPEN:
+            if credentials.xact_abort:
+                cls._apply_session_settings(conn)
+            else:
+                cls._warn_xact_abort_disabled_once()
+
         return conn
+
+    @classmethod
+    def _apply_session_settings(cls, connection: Connection) -> None:
+        """Set session-level defaults that must hold for every batch this
+        connection ever runs. Currently: XACT_ABORT, so a run-time error
+        mid-batch (e.g. a NOT NULL violation in a DELETE+INSERT swap) kills
+        the batch and rolls back any open transaction instead of falling
+        through to a trailing COMMIT. See dbt-msft/dbt-sqlserver#718.
+
+        A connection that fails this setup is not usable: it is closed and
+        the error is re-raised rather than handed back to dbt.
+        """
+        try:
+            cursor = connection.handle.cursor()
+            try:
+                cursor.execute("SET XACT_ABORT ON;")
+            finally:
+                cursor.close()
+
+            if not connection.handle.autocommit:
+                connection.handle.commit()
+        except Exception:
+            connection.handle.close()
+            connection.handle = None
+            connection.state = ConnectionState.FAIL
+            raise
+
+    @classmethod
+    def _warn_xact_abort_disabled_once(cls) -> None:
+        global _xact_abort_warning_logged
+        if _xact_abort_warning_logged:
+            return
+        _xact_abort_warning_logged = True
+
+        use_dbt_transactions = cls._dbt_sqlserver_use_dbt_transactions
+        msg = (
+            "xact_abort is disabled (xact_abort: false in the profile). Without "
+            "SET XACT_ABORT ON, a run-time error partway through a multi-statement "
+            "batch (e.g. the DELETE+INSERT swap in the DML refresh materialization) "
+            "aborts only the failing statement, not the batch, so a trailing COMMIT "
+            "can still commit a partial result. "
+            f"dbt_sqlserver_use_dbt_transactions is currently {use_dbt_transactions}"
+        )
+        if not use_dbt_transactions:
+            msg += (
+                " (dbt-managed transactions are off): the DML refresh materialization "
+                "emits its own in-batch BEGIN/COMMIT, and that in-batch swap can commit "
+                "a partial result in this configuration."
+            )
+        else:
+            msg += "."
+        logger.warning(msg)
 
     def cancel(self, connection: Connection) -> None:
         """Cancel the in-flight query on ``connection``, if any.

--- a/dbt/adapters/sqlserver/sqlserver_credentials.py
+++ b/dbt/adapters/sqlserver/sqlserver_credentials.py
@@ -56,6 +56,7 @@ class SQLServerCredentials(Credentials):
     schema_authorization: Optional[str] = None
     login_timeout: Optional[int] = 0
     query_timeout: Optional[int] = 0
+    xact_abort: bool = True
 
     _ALIASES = {
         "user": "UID",
@@ -104,6 +105,7 @@ class SQLServerCredentials(Credentials):
             "encrypt",
             "trust_cert",
             "backend",
+            "xact_abort",
         )
 
         if self.backend == SQLServerBackend.pyodbc:

--- a/dbt/include/sqlserver/macros/adapters/indexes.sql
+++ b/dbt/include/sqlserver/macros/adapters/indexes.sql
@@ -474,7 +474,8 @@
   {%- endfor %}
   {#- Apply all drops and creates in ONE transactional batch: a definition
       change is then atomic, with no window where a replacement index (or the
-      uniqueness it enforces) is missing for concurrent readers. xact_abort
+      uniqueness it enforces) is missing for concurrent readers. The
+      session-level SET XACT_ABORT ON applied at connection open (see #718)
       guarantees rollback if any statement fails mid-batch. -#}
   {%- set reconcile_statements = [] -%}
   {%- for index_name in result['drops'] %}
@@ -486,7 +487,7 @@
   {%- endfor %}
   {% if reconcile_statements %}
     {% do run_query(
-        "set xact_abort on;\nbegin transaction;\n"
+        "begin transaction;\n"
         ~ reconcile_statements | join(";\n")
         ~ ";\ncommit transaction;"
     ) %}

--- a/dbt/include/sqlserver/macros/materializations/models/table/table_dml_refresh.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/table/table_dml_refresh.sql
@@ -1,5 +1,15 @@
 {% macro sqlserver__table_dml_refresh(target_relation, sql) %}
   {#
+    The DELETE + INSERT swap below (dml_refresh_swap) is only safe because
+    every connection sets SET XACT_ABORT ON at session level (see
+    dbt/adapters/sqlserver/sqlserver_connections.py, xact_abort credential,
+    dbt-msft/dbt-sqlserver#718). Without it, a run-time error partway
+    through the swap (e.g. a NOT NULL/constraint violation on the INSERT)
+    only aborts that statement, not the batch — the DELETE can still
+    commit, silently emptying the target. Do not add a per-macro
+    SET XACT_ABORT ON here; the session-level default is the single source
+    of truth, and do not "simplify" this back into an unguarded batch.
+
     DML-only table refresh for use under RCSI.
 
     Instead of rename-swap (which uses DDL and creates a window where the

--- a/dbt/include/sqlserver/macros/relations/table/create.sql
+++ b/dbt/include/sqlserver/macros/relations/table/create.sql
@@ -140,9 +140,12 @@
             SELECT * FROM {{ tmp_relation }} {{ query_label }}
         {%- endset -%}
     {%- endif %}
-    {#- load and unmark atomically: any failure rolls back and keeps the marker -#}
+    {#- load and unmark atomically: any failure rolls back and keeps the marker.
+        Relies on the session-level SET XACT_ABORT ON applied at connection
+        open (see #718) so a run-time error here rolls back instead of
+        falling through to COMMIT; EXEC('...') runs in the same session, so
+        that setting still applies inside this dynamic SQL sub-batch. -#}
     {%- set insert_query -%}
-        SET XACT_ABORT ON;
         BEGIN TRANSACTION;
         {{ insert_statement }};
         EXEC sp_dropextendedproperty @name = N'dbt_full_refresh_incomplete',

--- a/tests/functional/adapter/mssql/test_xact_abort.py
+++ b/tests/functional/adapter/mssql/test_xact_abort.py
@@ -1,0 +1,189 @@
+import pytest
+
+from dbt.tests.util import get_connection, run_dbt
+
+# See dbt-msft/dbt-sqlserver#718: the DML refresh swap (DELETE + INSERT,
+# possibly wrapped in an explicit BEGIN/COMMIT batch) can commit a partial
+# result if a run-time error aborts only the failing statement instead of
+# the whole batch. These tests confirm the session-level `SET XACT_ABORT ON`
+# default (dbt/adapters/sqlserver/sqlserver_connections.py) prevents that.
+
+# -- Model fixtures --
+
+dml_check_model_seed_sql = """
+{{
+  config({
+    "materialized": "table",
+    "table_refresh_method": "dml",
+    "as_columnstore": False,
+    "post_hook": "ALTER TABLE {{ this }} ADD CONSTRAINT ck_val_not_null CHECK (val IS NOT NULL)"
+  })
+}}
+select 1 as id, cast('hello' as varchar(20)) as val
+union all
+select 2 as id, cast('world' as varchar(20)) as val
+"""
+
+dml_check_model_null_sql = """
+{{
+  config({
+    "materialized": "table",
+    "table_refresh_method": "dml",
+    "as_columnstore": False
+  })
+}}
+select 3 as id, cast(null as varchar(20)) as val
+"""
+
+
+def query_table(project, table_name):
+    """Query all rows from a table, return as list of tuples."""
+    sql = f"SELECT * FROM {project.test_schema}.{table_name} ORDER BY id"
+    with get_connection(project.adapter):
+        _, table = project.adapter.execute(sql, fetch=True)
+    return table.rows
+
+
+def write_model(project, filename, contents):
+    import os
+
+    path = os.path.join(project.project_root, "models", filename)
+    with open(path, "w") as f:
+        f.write(contents)
+
+
+# -- Data-loss regression + interaction matrix --
+#
+# Crossed with dbt_sqlserver_use_dbt_transactions per #718's own reasoning:
+# XACT_ABORT must protect the swap regardless of who owns the transaction
+# boundary, since the bug reproduces even with no explicit transaction at
+# all. xact_abort is left at its True default (via the shared profile) in
+# every class below — these are the combinations the fix is meant to
+# guarantee. See the module docstring-style comment near the bottom of this
+# file for why the xact_abort=False x dbt_transactions=False combination is
+# deliberately NOT asserted here.
+
+
+class BaseDmlRefreshConstraintViolationPreservesRows:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"dml_check_model.sql": dml_check_model_seed_sql}
+
+    def test_constraint_violation_does_not_lose_committed_rows(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        seeded_rows = query_table(project, "dml_check_model")
+        assert len(seeded_rows) == 2
+
+        # Swap in a model that yields a NULL in the CHECK-constrained column.
+        # Same (id int, val varchar(20)) schema as the seed model, so the DML
+        # refresh path (DELETE + INSERT) is taken rather than the
+        # rename-swap fallback.
+        write_model(project, "dml_check_model.sql", dml_check_model_null_sql)
+
+        run_dbt(["run"], expect_pass=False)
+
+        rows_after_failure = query_table(project, "dml_check_model")
+        assert len(rows_after_failure) == len(seeded_rows)
+
+
+class TestDmlRefreshConstraintViolationPreservesRowsDbtTransactionsOff(
+    BaseDmlRefreshConstraintViolationPreservesRows
+):
+    """xact_abort: true (default), dbt_sqlserver_use_dbt_transactions: false (default).
+
+    This is the exact scenario in #718's background: the macro emits its own
+    BEGIN TRANSACTION / COMMIT TRANSACTION around DELETE + INSERT as one
+    autocommit batch. Without the session-level XACT_ABORT default, the
+    DELETE would commit before the INSERT's constraint violation is
+    noticed. With it, the whole batch aborts and rolls back.
+    """
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"dbt_sqlserver_use_dbt_transactions": False}}
+
+
+class TestDmlRefreshConstraintViolationPreservesRowsDbtTransactionsOn(
+    BaseDmlRefreshConstraintViolationPreservesRows
+):
+    """xact_abort: true (default), dbt_sqlserver_use_dbt_transactions: true.
+
+    Here dbt owns the transaction boundary (its own BEGIN/COMMIT statements,
+    separate from the swap batch), so this also confirms XACT_ABORT doesn't
+    interfere with dbt-managed transactions.
+    """
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"dbt_sqlserver_use_dbt_transactions": True}}
+
+
+class TestDmlRefreshConstraintViolationPreservesRowsXactAbortOffDbtTransactionsOn(
+    BaseDmlRefreshConstraintViolationPreservesRows
+):
+    """xact_abort: false, dbt_sqlserver_use_dbt_transactions: true.
+
+    With xact_abort off, protection now depends entirely on dbt owning the
+    transaction: the macro sends no BEGIN/COMMIT text of its own here (dbt
+    already opened one), so a statement-abort-only error leaves @@TRANCOUNT
+    > 0 and dbt's own rollback path (SQLServerConnectionManager._rollback_handle)
+    issues `IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION` — never a commit. Rows
+    are preserved here, but via dbt's transaction ownership, not XACT_ABORT.
+    """
+
+    @pytest.fixture(scope="class")
+    def dbt_profile_target_update(self):
+        return {"xact_abort": False}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"dbt_sqlserver_use_dbt_transactions": True}}
+
+
+# Deliberately not covered above: xact_abort=False with
+# dbt_sqlserver_use_dbt_transactions=False (both disabled). In that specific
+# combination the macro's own BEGIN/COMMIT text wraps an autocommit batch
+# with no XACT_ABORT protection and no dbt-managed rollback to fall back on,
+# so a statement-abort error can commit the DELETE and lose the row. That is
+# the documented, intentional consequence of disabling xact_abort (see the
+# warning in SQLServerConnectionManager._warn_xact_abort_disabled_once) —
+# not a regression to assert against here. Confirming it empirically
+# requires a live SQL Server instance; see the PR description.
+
+
+# -- Session-level XACT_ABORT is actually set on the connection --
+
+
+class TestXactAbortSessionOptionEnabledByDefault:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {}
+
+    def test_xact_abort_option_bit_is_set(self, project):
+        with get_connection(project.adapter):
+            _, table = project.adapter.execute(
+                "SELECT CASE WHEN (@@OPTIONS & 16384) > 0 THEN 1 ELSE 0 END AS xact_abort_on",
+                fetch=True,
+            )
+        assert table.rows[0][0] == 1
+
+
+class TestXactAbortSessionOptionUnsetWhenDisabled:
+    @pytest.fixture(scope="class")
+    def dbt_profile_target_update(self):
+        return {"xact_abort": False}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {}
+
+    def test_xact_abort_option_bit_is_unset(self, project):
+        with get_connection(project.adapter):
+            _, table = project.adapter.execute(
+                "SELECT CASE WHEN (@@OPTIONS & 16384) > 0 THEN 1 ELSE 0 END AS xact_abort_on",
+                fetch=True,
+            )
+        assert table.rows[0][0] == 0

--- a/tests/unit/adapters/mssql/conftest.py
+++ b/tests/unit/adapters/mssql/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+from dbt.adapters.sqlserver.sqlserver_runtime import reset_runtime_state_for_test
+
+
+@pytest.fixture(autouse=True)
+def _reset_sqlserver_runtime_state():
+    """_RUNTIME_STATE (dbt/adapters/sqlserver/sqlserver_runtime.py) is a
+    process-global module cache. Tests here stub it with fake pyodbc /
+    mssql-python modules via configure_runtime_state_for_test(); without a
+    reset after each test, whichever test runs last leaks its fake module
+    into every test that follows in the same process — including real
+    functional tests, which then try to connect through the fake stub
+    instead of the real driver."""
+    reset_runtime_state_for_test()
+    yield
+    reset_runtime_state_for_test()

--- a/tests/unit/adapters/mssql/test_sqlserver_connection_manager.py
+++ b/tests/unit/adapters/mssql/test_sqlserver_connection_manager.py
@@ -287,6 +287,28 @@ def test_connection_keys_include_driver_only_for_pyodbc() -> None:
     assert "windows_login" in mssql_python_credentials._connection_keys()
 
 
+def test_xact_abort_defaults_to_true() -> None:
+    credentials = SQLServerCredentials(
+        driver="ODBC Driver 18 for SQL Server",
+        host="fake.sql.sqlserver.net",
+        database="dbt",
+        schema="sqlserver",
+    )
+
+    assert credentials.xact_abort is True
+
+
+def test_connection_keys_include_xact_abort() -> None:
+    credentials = SQLServerCredentials(
+        driver="ODBC Driver 18 for SQL Server",
+        host="fake.sql.sqlserver.net",
+        database="dbt",
+        schema="sqlserver",
+    )
+
+    assert "xact_abort" in credentials._connection_keys()
+
+
 def test_is_pyodbc_handle_false_for_mssql_python_handle() -> None:
     handle = type("Handle", (), {"driver_type": "mssql-python"})()
     assert _is_pyodbc_handle(handle) is False
@@ -859,6 +881,13 @@ def test_open_with_mssql_python_backend_system_assigned_msi_passes_connection_st
     class FakeHandle:
         def __init__(self):
             self.timeout = None
+            self.autocommit = True
+
+        def cursor(self):
+            return SimpleNamespace(execute=lambda sql: None, close=lambda: None)
+
+        def close(self):
+            pass
 
     def fake_connect(connection_string, autocommit, timeout):
         captured["connection_string"] = connection_string
@@ -1196,6 +1225,42 @@ def _fake_pyodbc_module(connect):
     )
 
 
+class _FakeSessionCursor:
+    def __init__(self, fail: bool = False):
+        self.executed: List[str] = []
+        self.closed = False
+        self._fail = fail
+
+    def execute(self, sql):
+        if self._fail:
+            raise RuntimeError("boom")
+        self.executed.append(sql)
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeSessionHandle:
+    """Minimal handle standing in for a pyodbc/mssql-python connection,
+    covering just the surface _apply_session_settings touches."""
+
+    def __init__(self, autocommit: bool = True, fail_execute: bool = False):
+        self.autocommit = autocommit
+        self.timeout = None
+        self.cursor_obj = _FakeSessionCursor(fail=fail_execute)
+        self.commit_calls = 0
+        self.closed = False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.commit_calls += 1
+
+    def close(self):
+        self.closed = True
+
+
 def test_open_with_mssql_python_backend_enables_pooling(
     credentials: SQLServerCredentials, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1215,6 +1280,13 @@ def test_open_with_mssql_python_backend_enables_pooling(
     class FakeHandle:
         def __init__(self):
             self.timeout = None
+            self.autocommit = True
+
+        def cursor(self):
+            return SimpleNamespace(execute=lambda sql: None, close=lambda: None)
+
+        def close(self):
+            pass
 
     fake_handle = FakeHandle()
 
@@ -1348,6 +1420,13 @@ def test_open_with_mssql_python_backend_supported_managed_identity_auth(
     class FakeHandle:
         def __init__(self):
             self.timeout = None
+            self.autocommit = True
+
+        def cursor(self):
+            return SimpleNamespace(execute=lambda sql: None, close=lambda: None)
+
+        def close(self):
+            pass
 
     def fake_connect(connection_string, autocommit, timeout):
         captured["connection_string"] = connection_string
@@ -1447,6 +1526,13 @@ def test_open_with_pyodbc_backend_enables_driver_pooling(
     class FakeHandle:
         def __init__(self):
             self.timeout = None
+            self.autocommit = True
+
+        def cursor(self):
+            return SimpleNamespace(execute=lambda sql: None, close=lambda: None)
+
+        def close(self):
+            pass
 
     def fake_connect(connection_string, attrs_before, autocommit, timeout):
         captured["connection_string"] = connection_string
@@ -1474,6 +1560,125 @@ def test_open_with_pyodbc_backend_enables_driver_pooling(
     assert captured["autocommit"] is True
     assert captured["timeout"] == credentials.login_timeout
     assert "Pooling=true" in captured["connection_string"]
+
+
+def _open_with_fake_handle(
+    credentials: SQLServerCredentials,
+    monkeypatch: pytest.MonkeyPatch,
+    handle: _FakeSessionHandle,
+) -> Connection:
+    fake_pyodbc = _fake_pyodbc_module(lambda *args, **kwargs: handle)
+
+    reset_runtime_state_for_test()
+    configure_runtime_state_for_test(pyodbc_module=fake_pyodbc, pyodbc_import_error=None)
+    monkeypatch.setattr(
+        SQLServerConnectionManager,
+        "retry_connection",
+        classmethod(_fake_retry_connection_stub()),
+    )
+
+    connection = Connection(type="sqlserver", name="pyodbc-test", credentials=credentials)
+    return SQLServerConnectionManager.open(connection)
+
+
+def test_open_applies_xact_abort_session_setting_by_default(
+    credentials: SQLServerCredentials,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credentials.UID = "dbt_user"
+    credentials.PWD = "super-secret"
+    assert credentials.xact_abort is True
+
+    handle = _FakeSessionHandle(autocommit=True)
+    opened = _open_with_fake_handle(credentials, monkeypatch, handle)
+
+    assert opened.state == ConnectionState.OPEN
+    assert handle.cursor_obj.executed == ["SET XACT_ABORT ON;"]
+    assert handle.cursor_obj.closed is True
+    assert handle.commit_calls == 0
+
+
+def test_open_commits_after_session_settings_when_handle_not_autocommit(
+    credentials: SQLServerCredentials,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credentials.UID = "dbt_user"
+    credentials.PWD = "super-secret"
+
+    handle = _FakeSessionHandle(autocommit=False)
+    opened = _open_with_fake_handle(credentials, monkeypatch, handle)
+
+    assert opened.state == ConnectionState.OPEN
+    assert handle.cursor_obj.executed == ["SET XACT_ABORT ON;"]
+    assert handle.commit_calls == 1
+
+
+def test_open_skips_session_settings_and_warns_once_when_xact_abort_disabled(
+    credentials: SQLServerCredentials,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credentials.UID = "dbt_user"
+    credentials.PWD = "super-secret"
+    credentials.xact_abort = False
+
+    handle = _FakeSessionHandle(autocommit=True)
+    monkeypatch.setattr(sqlserver_connections, "_xact_abort_warning_logged", False)
+
+    with patch("dbt.adapters.sqlserver.sqlserver_connections.logger") as mock_logger:
+        opened = _open_with_fake_handle(credentials, monkeypatch, handle)
+
+    assert opened.state == ConnectionState.OPEN
+    assert handle.cursor_obj.executed == []
+    assert handle.commit_calls == 0
+    mock_logger.warning.assert_called_once()
+
+
+def test_apply_session_settings_closes_connection_and_reraises_on_failure(
+    credentials: SQLServerCredentials,
+) -> None:
+    handle = _FakeSessionHandle(autocommit=True, fail_execute=True)
+    connection = Connection(type="sqlserver", name="pyodbc-test", credentials=credentials)
+    connection.handle = handle
+    connection.state = ConnectionState.OPEN
+
+    with pytest.raises(RuntimeError, match="boom"):
+        SQLServerConnectionManager._apply_session_settings(connection)
+
+    assert handle.closed is True
+    assert connection.handle is None
+    assert connection.state == ConnectionState.FAIL
+
+
+def test_warn_xact_abort_disabled_once_fires_only_once_per_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sqlserver_connections, "_xact_abort_warning_logged", False)
+    monkeypatch.setattr(SQLServerConnectionManager, "_dbt_sqlserver_use_dbt_transactions", False)
+
+    with patch("dbt.adapters.sqlserver.sqlserver_connections.logger") as mock_logger:
+        SQLServerConnectionManager._warn_xact_abort_disabled_once()
+        SQLServerConnectionManager._warn_xact_abort_disabled_once()
+
+    mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.parametrize("use_dbt_transactions", [True, False])
+def test_warn_xact_abort_disabled_once_mentions_dbt_transactions_state(
+    monkeypatch: pytest.MonkeyPatch,
+    use_dbt_transactions: bool,
+) -> None:
+    monkeypatch.setattr(sqlserver_connections, "_xact_abort_warning_logged", False)
+    monkeypatch.setattr(
+        SQLServerConnectionManager, "_dbt_sqlserver_use_dbt_transactions", use_dbt_transactions
+    )
+
+    with patch("dbt.adapters.sqlserver.sqlserver_connections.logger") as mock_logger:
+        SQLServerConnectionManager._warn_xact_abort_disabled_once()
+
+    message = mock_logger.warning.call_args[0][0]
+    assert str(use_dbt_transactions) in message
+    if not use_dbt_transactions:
+        assert "DML refresh" in message
 
 
 @pytest.mark.parametrize("flag_value", [True, False])


### PR DESCRIPTION
## Summary

Closes #718.

`table_dml_refresh` and other multi-statement paths (index reconcile, prebuilt full-refresh) send DML as one autocommit batch (`BEGIN; DELETE; INSERT; COMMIT`). A statement-abort error (NOT NULL, constraint violation, etc.) only aborts that statement, not the batch — execution falls through to `COMMIT`, silently persisting the `DELETE` on an empty target even though dbt reports failure. This also happens with no explicit transaction at all, so the fix can't depend on `dbt_sqlserver_use_dbt_transactions`.

Fix: `SET XACT_ABORT ON` as a **session-level default on every connection**, so a run-time error kills the whole batch and rolls back instead of falling through to `COMMIT`.

## Changes

- `xact_abort: bool = True` credentials field (in `_connection_keys()`, shows in `dbt debug`). Independent of `dbt_sqlserver_use_dbt_transactions` — that flag decides who owns the transaction boundary; `xact_abort` decides how the server reacts to a mid-batch error, which matters most exactly when there's no explicit transaction.
- `open()` applies it via new `_apply_session_settings()`; a connection that fails this setup is closed rather than handed back to dbt.
- Once-per-process warning when disabled, noting the current `dbt_sqlserver_use_dbt_transactions` state.
- Removed the now-redundant local `SET XACT_ABORT ON` from `indexes.sql` and `create.sql` — session-level is the single source of truth. Comment added above `table_dml_refresh` pointing at #718.
- README + CHANGELOG (labeled as a behavior change, default-on in an already-published 1.11.x line).

## Testing

New functional suite (`test_xact_abort.py`) against a real SQL Server:
- Seed 2 rows via DML refresh, second run yields NULL → run fails **and** the 2 rows survive (the row-count assertion is the point; pre-fix, the run also fails but the table is empty).
- `xact_abort=True` × `dbt_sqlserver_use_dbt_transactions` on/off: rows preserved both ways.
- `xact_abort=False` + transactions on: preserved via dbt's own rollback, not XACT_ABORT.
- `xact_abort=False` + transactions off (both disabled): **not** asserted as passing — manually confirmed this still loses rows, which is the documented, intentional limit of disabling the flag, not a regression.
- `@@OPTIONS & 16384` bit check: 1 by default, 0 when disabled.

Full suite: `pytest tests/unit tests/functional -n auto` → **600 passed, 48 skipped, 2 xfailed, 0 failed** (298s).

**Also fixed along the way:** a pre-existing test-isolation bug where unit tests stub a process-global driver-module cache (`_RUNTIME_STATE`) without resetting it, leaking a fake module into real functional tests when both run in one `pytest` process. Added an autouse reset fixture. Also added `-n auto` to the integration-tests CI workflow (verified safe locally).

## Notes

Based directly on current upstream `master`, independent of #763 (UDF function resource support) — no shared files besides `table_dml_refresh.sql`, where this PR's change applies cleanly against the Dynamic Data Masking code already on `master`.