### PR TITLE
chore: replace black with ruff format

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,5 @@
 4eff3237f2bf9d3d206c9234353fb07e70ac6013
 # Updated README.md and blackified the code.
 29bab50f0e7d9e09b9110500f6e41e1255d3f3f6
+# Replaced black with ruff format.
+3d77e975c41bb6be2a13afd0df8cbb596d84fe9f

--- a/.github/scripts/verify_version.py
+++ b/.github/scripts/verify_version.py
@@ -36,7 +36,7 @@ def main(argv: list[str]) -> int:
     pkg_version = read_package_version()
     if tag_version != pkg_version:
         print(
-            f"Git tag {tag_version!r} does not match " f"package version {pkg_version!r}",
+            f"Git tag {tag_version!r} does not match package version {pkg_version!r}",
             file=sys.stderr,
         )
         return 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,20 +37,12 @@ repos:
         alias: ruff-check-manual
         stages:
           - manual
-  - repo: 'https://github.com/psf/black'
-    rev: 26.5.1
-    hooks:
-      - id: black
-        args:
-          - '--line-length=99'
-          - '--target-version=py311'
-      - id: black
-        alias: black-check
+      - id: ruff-format
+      - id: ruff-format
+        alias: ruff-format-check
         stages:
           - manual
         args:
-          - '--line-length=99'
-          - '--target-version=py311'
           - '--check'
           - '--diff'
   - repo: 'https://github.com/pre-commit/mirrors-mypy'

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ ruff: ## Runs ruff against staged changes to enforce style guide.
 	@\
 	pre-commit run --hook-stage manual ruff-check-manual | grep -v "INFO"
 
-.PHONY: black
-black: ## Runs black  against staged changes to enforce style guide.
+.PHONY: format
+format: ## Runs ruff format against staged changes to enforce style guide.
 	@\
-	pre-commit run --hook-stage manual black-check -v | grep -v "INFO"
+	pre-commit run --hook-stage manual ruff-format-check -v | grep -v "INFO"
 
 .PHONY: lint
 lint: ## Runs ruff and mypy code checks against staged changes.
@@ -46,7 +46,7 @@ functional: ## Runs functional tests.
 test: ## Runs unit tests and code checks against staged changes.
 	@\
 	uv run pytest -n auto -ra -v tests/unit; \
-	pre-commit run black-check --hook-stage manual | grep -v "INFO"; \
+	pre-commit run ruff-format-check --hook-stage manual | grep -v "INFO"; \
 	pre-commit run ruff-check-manual --hook-stage manual | grep -v "INFO"; \
 	pre-commit run mypy-check --hook-stage manual | grep -v "INFO"
 

--- a/dbt/adapters/sqlserver/sqlserver_relation.py
+++ b/dbt/adapters/sqlserver/sqlserver_relation.py
@@ -71,13 +71,11 @@ class SQLServerRelation(BaseRelation):
             )
         elif event_time_filter.start:
             filter = (
-                f"{event_time_filter.field_name} >="
-                f" cast('{event_time_filter.start}' as datetime2)"
+                f"{event_time_filter.field_name} >= cast('{event_time_filter.start}' as datetime2)"
             )
         elif event_time_filter.end:
             filter = (
-                f"{event_time_filter.field_name} <"
-                f" cast('{event_time_filter.end}' as datetime2)"
+                f"{event_time_filter.field_name} < cast('{event_time_filter.end}' as datetime2)"
             )
 
         return filter

--- a/tests/functional/adapter/dbt/test_basic.py
+++ b/tests/functional/adapter/dbt/test_basic.py
@@ -16,7 +16,6 @@ from dbt.tests.util import run_dbt
 
 
 class TestSimpleMaterializations(BaseSimpleMaterializations):
-
     def test_existing_view_materialization(self, project, models):
         """Test that materializing an existing view works correctly."""
         # Create a temporary model file directly in the project

--- a/tests/functional/adapter/dbt/test_caching.py
+++ b/tests/functional/adapter/dbt/test_caching.py
@@ -12,10 +12,12 @@ class TestCachingLowercaseModel(BaseCachingLowercaseModel):
     pass
 
 
-@pytest.mark.skip(reason="""
+@pytest.mark.skip(
+    reason="""
     Fails because of case sensitivity.
     MODEL is coereced to model which fails the test as it sees conflicting naming
-    """)
+    """
+)
 class TestCachingUppercaseModel(BaseCachingUppercaseModel):
     pass
 

--- a/tests/functional/adapter/dbt/test_data_types.py
+++ b/tests/functional/adapter/dbt/test_data_types.py
@@ -34,9 +34,9 @@ class TestTypeStringSQLServer(BaseTypeString):
     def assert_columns_equal(self, project, expected_cols, actual_cols):
         #  ignore the size of the varchar since we do
         #  an optimization to not use varchar(max) all the time
-        assert (
-            expected_cols[:-1] == actual_cols[:-1]
-        ), f"Type difference detected: {expected_cols} vs. {actual_cols}"
+        assert expected_cols[:-1] == actual_cols[:-1], (
+            f"Type difference detected: {expected_cols} vs. {actual_cols}"
+        )
 
 
 class TestTypeTimestampSQLServer(BaseTypeTimestamp):

--- a/tests/functional/adapter/dbt/test_dbt_show.py
+++ b/tests/functional/adapter/dbt/test_dbt_show.py
@@ -40,7 +40,7 @@ class BaseShowLimit:
         limit = results.args.get("limit")
         if limit > 0:
             assert (
-                f"offset 0 rows fetch first { limit } rows only"
+                f"offset 0 rows fetch first {limit} rows only"
                 in results.results[0].node.compiled_code
             )
 

--- a/tests/functional/adapter/dbt/test_hooks.py
+++ b/tests/functional/adapter/dbt/test_hooks.py
@@ -129,12 +129,12 @@ class BaseTestPrePost:
             # assert ctx["target_user"] == "root"
             # assert ctx["target_pass"] == ""
 
-            assert (
-                ctx["run_started_at"] is not None and len(ctx["run_started_at"]) > 0
-            ), "run_started_at was not set"
-            assert (
-                ctx["invocation_id"] is not None and len(ctx["invocation_id"]) > 0
-            ), "invocation_id was not set"
+            assert ctx["run_started_at"] is not None and len(ctx["run_started_at"]) > 0, (
+                "run_started_at was not set"
+            )
+            assert ctx["invocation_id"] is not None and len(ctx["invocation_id"]) > 0, (
+                "invocation_id was not set"
+            )
             assert ctx["thread_id"].startswith("Thread-")
 
 
@@ -196,7 +196,8 @@ class BaseHookRefs(BaseTestPrePost):
             "models": {
                 "test": {
                     "hooked": {
-                        "post-hook": ["""
+                        "post-hook": [
+                            """
                         insert into {{this.schema}}.on_model_hook select
                         test_state,
                         '{{ target.dbname }}' as target_dbname,
@@ -210,7 +211,8 @@ class BaseHookRefs(BaseTestPrePost):
                         '{{ run_started_at }}' as run_started_at,
                         '{{ invocation_id }}' as invocation_id,
                         '{{ thread_id }}' as thread_id
-                        from {{ ref('post') }}""".strip()],
+                        from {{ ref('post') }}""".strip()
+                        ],
                     }
                 },
             }

--- a/tests/functional/adapter/dbt/test_simple_seed.py
+++ b/tests/functional/adapter/dbt/test_simple_seed.py
@@ -163,10 +163,12 @@ class TestSimpleSeedEnabledViaConfig__seed_with_disabled(BaseSimpleSeedEnabledVi
         check_table_does_not_exist(project.adapter, "seed_disabled")
         check_table_does_exist(project.adapter, "seed_tricky")
 
-    @pytest.mark.skip(reason="""
+    @pytest.mark.skip(
+        reason="""
         Running all the tests in the same schema causes the tests to fail
         as they all share the same schema across the tests
-        """)
+        """
+    )
     def test_simple_seed_selection(self, clear_test_schema, project):
         results = run_dbt(["seed", "--select", "seed_enabled"])
         assert len(results) == 1
@@ -174,10 +176,12 @@ class TestSimpleSeedEnabledViaConfig__seed_with_disabled(BaseSimpleSeedEnabledVi
         check_table_does_not_exist(project.adapter, "seed_disabled")
         check_table_does_not_exist(project.adapter, "seed_tricky")
 
-    @pytest.mark.skip(reason="""
+    @pytest.mark.skip(
+        reason="""
         Running all the tests in the same schema causes the tests to fail
         as they all share the same schema across the tests
-        """)
+        """
+    )
     def test_simple_seed_exclude(self, clear_test_schema, project):
         results = run_dbt(["seed", "--exclude", "seed_enabled"])
         assert len(results) == 1
@@ -204,10 +208,12 @@ class TestSimpleSeedEnabledViaConfig__seed_selection(BaseSimpleSeedEnabledViaCon
         project.run_sql(f"drop view if exists {project.test_schema}.seed_tricky")
         project.run_sql(f"drop schema if exists {project.test_schema}")
 
-    @pytest.mark.skip(reason="""
+    @pytest.mark.skip(
+        reason="""
         Running all the tests in the same schema causes the tests to fail
         as they all share the same schema across the tests
-        """)
+        """
+    )
     def test_simple_seed_with_disabled(self, clear_test_schema, project):
         results = run_dbt(["seed"])
         assert len(results) == 2
@@ -222,10 +228,12 @@ class TestSimpleSeedEnabledViaConfig__seed_selection(BaseSimpleSeedEnabledViaCon
         check_table_does_not_exist(project.adapter, "seed_disabled")
         check_table_does_not_exist(project.adapter, "seed_tricky")
 
-    @pytest.mark.skip(reason="""
+    @pytest.mark.skip(
+        reason="""
         Running all the tests in the same schema causes the tests to fail
         as they all share the same schema across the tests
-        """)
+        """
+    )
     def test_simple_seed_exclude(self, clear_test_schema, project):
         results = run_dbt(["seed", "--exclude", "seed_enabled"])
         assert len(results) == 1
@@ -252,10 +260,12 @@ class TestSimpleSeedEnabledViaConfig__seed_exclude(BaseSimpleSeedEnabledViaConfi
         project.run_sql(f"drop view if exists {project.test_schema}.seed_tricky")
         project.run_sql(f"drop schema if exists {project.test_schema}")
 
-    @pytest.mark.skip(reason="""
+    @pytest.mark.skip(
+        reason="""
         Running all the tests in the same schema causes the tests to fail
         as they all share the same schema across the tests
-        """)
+        """
+    )
     def test_simple_seed_with_disabled(self, clear_test_schema, project):
         results = run_dbt(["seed"])
         assert len(results) == 2
@@ -263,10 +273,12 @@ class TestSimpleSeedEnabledViaConfig__seed_exclude(BaseSimpleSeedEnabledViaConfi
         check_table_does_not_exist(project.adapter, "seed_disabled")
         check_table_does_exist(project.adapter, "seed_tricky")
 
-    @pytest.mark.skip(reason="""
+    @pytest.mark.skip(
+        reason="""
         Running all the tests in the same schema causes the tests to fail
         as they all share the same schema across the tests
-        """)
+        """
+    )
     def test_simple_seed_selection(self, clear_test_schema, project):
         results = run_dbt(["seed", "--select", "seed_enabled"])
         assert len(results) == 1

--- a/tests/functional/adapter/dbt/test_utils.py
+++ b/tests/functional/adapter/dbt/test_utils.py
@@ -364,10 +364,12 @@ class TestStringLiteral(BaseStringLiteral):
     pass
 
 
-@pytest.mark.skip(reason="""
+@pytest.mark.skip(
+    reason="""
                   comment here about why this is skipped.
                   https://github.com/dbt-labs/dbt-adapters/blob/f1987d4313cc94bac9906963dff1337ee0bffbc6/dbt/include/global_project/macros/adapters/timestamps.sql#L39
-                  """)
+                  """
+)
 class TestCurrentTimestamps(BaseCurrentTimestamps):
     pass
 

--- a/tests/functional/adapter/mssql/test_index_config.py
+++ b/tests/functional/adapter/mssql/test_index_config.py
@@ -55,7 +55,9 @@ and index_id > 0
 )
 """
 
-index_count = base_validation + """
+index_count = (
+    base_validation
+    + """
 select
   index_type + case when [unique] = 'Unique' then ' unique' else '' end as index_type,
   count(*) index_count
@@ -65,8 +67,11 @@ WHERE
   schema_name='{schema_name}'
 group by index_type + case when [unique] = 'Unique' then ' unique' else '' end
 """
+)
 
-indexes_def = base_validation + """
+indexes_def = (
+    base_validation
+    + """
 SELECT
   index_name,
   [columns],
@@ -84,6 +89,7 @@ WHERE
   table_view='{schema_name}.{table_name}'
 
 """
+)
 
 # Altered from: https://github.com/dbt-labs/dbt-postgres
 
@@ -898,7 +904,7 @@ class TestSQLServerClusteredCollision:
     def test_clustered_collision_fails_with_clear_error(self, project, unique_schema):
         run_dbt(["run", "--models", "collision"])
         project.run_sql(
-            f"CREATE CLUSTERED INDEX ix_dba_clustered " f"ON {unique_schema}.collision (column_a)"
+            f"CREATE CLUSTERED INDEX ix_dba_clustered ON {unique_schema}.collision (column_a)"
         )
 
         _, output = run_dbt_and_capture(

--- a/tests/functional/adapter/mssql/test_query_options.py
+++ b/tests/functional/adapter/mssql/test_query_options.py
@@ -432,7 +432,8 @@ class TestApplyLabelBackwardCompat:
 
     @pytest.fixture(scope="class")
     def macros(self):
-        return {"verify_apply_label.sql": """
+        return {
+            "verify_apply_label.sql": """
 {% macro verify_apply_label() %}
     {%- set result = apply_label() -%}
     {{ log("apply_label returned: " ~ result, info=True) }}
@@ -443,7 +444,8 @@ class TestApplyLabelBackwardCompat:
         {{ exceptions.raise_compiler_error("apply_label() must not emit query_options hints") }}
     {%- endif -%}
 {% endmacro %}
-"""}
+"""
+        }
 
     def test_apply_label_callable_and_label_only(self, project):
         # run-operation will fail (non-zero exit) if apply_label is undefined
@@ -904,9 +906,9 @@ class TestQueryOptionsOnDmlRefresh:
             logs,
             re.IGNORECASE,
         )
-        assert (
-            main_match is not None
-        ), "query_options missing from the 'main' SELECT INTO statement of the DML refresh"
+        assert main_match is not None, (
+            "query_options missing from the 'main' SELECT INTO statement of the DML refresh"
+        )
 
         # 'dml_refresh_swap' — INSERT ... SELECT ... FROM <scratch>, must carry
         # the hint too. The INSERT...SELECT spans newlines but has no interior
@@ -916,9 +918,9 @@ class TestQueryOptionsOnDmlRefresh:
             logs,
             re.IGNORECASE,
         )
-        assert (
-            swap_match is not None
-        ), "query_options missing from the 'dml_refresh_swap' INSERT statement of the DML refresh"
+        assert swap_match is not None, (
+            "query_options missing from the 'dml_refresh_swap' INSERT statement of the DML refresh"
+        )
 
 
 def write_model(project, filename, contents):

--- a/tests/functional/adapter/mssql/test_reserved_keywords_schema.py
+++ b/tests/functional/adapter/mssql/test_reserved_keywords_schema.py
@@ -31,7 +31,8 @@ class TestReservedKeywordsSchema:
 
     @pytest.fixture(scope="class")
     def macros(self):
-        return {"generate_schema_name.sql": """
+        return {
+            "generate_schema_name.sql": """
 {% macro generate_schema_name(custom_schema_name, node) -%}
     {%- if custom_schema_name -%}
         {{ custom_schema_name | trim }}
@@ -39,7 +40,8 @@ class TestReservedKeywordsSchema:
         {{ target.schema }}
     {%- endif -%}
 {%- endmacro %}
-"""}
+"""
+        }
 
     @pytest.fixture(autouse=True, scope="class")
     def cleanup_schema(self, project):


### PR DESCRIPTION
## Summary

Closes #711. This finishes what #707 started. That PR moved linting to Ruff but left `black` in place as the formatter. This PR swaps `black` for `ruff format`, so one tool and one config block now cover both jobs.

The two `black` hooks are gone. In their place are two `ruff-format` hooks inside the `astral-sh/ruff-pre-commit` block we already have, matching the pattern of the existing `ruff-check` hooks: one that fixes on commit, one manual alias named `ruff-format-check` that runs `--check --diff`.

No new configuration. `ruff format` reads `line-length = 99` and `target-version = "py311"` from the `[tool.ruff]` block that #707 added.

## Why

- One toolchain. After #707 we were running two formatters' worth of tooling for one job. Now it is a single Rust binary, a single version pin, and a single config block for lint and format together.
- Fewer dependencies. Ruff is a self-contained binary. `black` pulls in `click`, `mypy-extensions`, `packaging`, `pathspec`, `platformdirs`, and `pytokens`. Dropping it removes one more consumer of `pathspec`, the package behind the `override-dependencies` workaround in `pyproject.toml`. That workaround still has to stay, but this is one less thing depending on it.
- Speed. Warm `--check` over `dbt/` and `tests/` is roughly 0.06s for `ruff format` against 0.27s for `black`. Small in absolute terms, but it adds up across pre-commit and CI.
- Low risk. Ruff targets better than 99.9% black compatibility, which is why the diff below is as small as it is.

## What changed in the code

Twelve files, all cosmetic:

- `dbt/adapters/sqlserver/sqlserver_relation.py`. Two implicit f-string concatenations get joined onto one line now that they fit in 99 columns. Same string either way.
- `.github/scripts/verify_version.py`. Same thing, one joined concatenation. This one was not in the issue write-up, which only measured `dbt/` and `tests/`. Pre-commit runs over every tracked Python file, so it turned up.
- Ten files under `tests/functional/`. A blank line removed after a class header, `assert cond, (msg)` reflowed, decorator arguments wrapped, and `f"{ limit }"` normalised to `f"{limit}"`. Whitespace inside f-string braces is not part of the output, so that last one is a no-op at runtime.

`make black` becomes `make format`. `make test` checks formatting through `ruff-format-check`.

The reformat commit is listed in `.git-blame-ignore-revs`, alongside the two entries already there. GitHub's blame view honours that file automatically. Worth keeping the two commits separate on merge, since a squash would leave the recorded SHA pointing at nothing. Git tolerates an unresolvable entry silently, so nothing breaks either way, but the entry would stop doing its job.

## Verification

- `pre-commit run --all-files` passes every hook: ruff check, ruff format, mypy, yamllint, and the pre-commit-hooks set.
- `mypy 2.1.0` clean on 17 source files.
- Unit tests: 303 passed.
- Functional tests not run locally, they need a live SQL Server. The test edits are formatting only.

## Trade-offs

- One-time blame churn on twelve files, ten of them tests. Handled by the `.git-blame-ignore-revs` entry.
- Diverges from `dbt-labs/dbt-adapters`, which still uses `black`. Given how close ruff's output is, this should not matter in practice.
- The manual hook alias is named `ruff-format-check`, not `black-check`. Anyone with a local script or muscle memory for `make black` will need to switch to `make format`.

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Unit tests pass (303)
- [x] Reformat is cosmetic only, no behaviour change
- [x] Reformat commit recorded in `.git-blame-ignore-revs`
