### PR TITLE
fix: make check targets runnable and honest about failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,33 +4,34 @@ THREADS ?= auto
 .PHONY: dev
 dev: ## Installs adapter in develop mode along with development dependencies
 	@\
-	uv sync --all-extras && pre-commit install
+	uv sync --all-extras && uv run pre-commit install
 
 .PHONY: mypy
 mypy: ## Runs mypy against staged changes for static type checking.
 	@\
-	pre-commit run --hook-stage manual mypy-check | grep -v "INFO"
+	uv run pre-commit run --hook-stage manual mypy-check
 
 .PHONY: ruff
 ruff: ## Runs ruff against staged changes to enforce style guide.
 	@\
-	pre-commit run --hook-stage manual ruff-check-manual | grep -v "INFO"
+	uv run pre-commit run --hook-stage manual ruff-check-manual
 
 .PHONY: format
 format: ## Runs ruff format against staged changes to enforce style guide.
 	@\
-	pre-commit run --hook-stage manual ruff-format-check -v | grep -v "INFO"
+	uv run pre-commit run --hook-stage manual ruff-format-check -v
 
 .PHONY: lint
 lint: ## Runs ruff and mypy code checks against staged changes.
-	@\
-	pre-commit run ruff-check-manual --hook-stage manual | grep -v "INFO"; \
-	pre-commit run mypy-check --hook-stage manual | grep -v "INFO"
+	@status=0; \
+	uv run pre-commit run ruff-check-manual --hook-stage manual || status=1; \
+	uv run pre-commit run mypy-check --hook-stage manual || status=1; \
+	exit $$status
 
 .PHONY: all
 all: ## Runs all checks against staged changes.
 	@\
-	pre-commit run -a
+	uv run pre-commit run -a
 
 .PHONY: unit
 unit: ## Runs unit tests.
@@ -44,11 +45,12 @@ functional: ## Runs functional tests.
 
 .PHONY: test
 test: ## Runs unit tests and code checks against staged changes.
-	@\
-	uv run pytest -n auto -ra -v tests/unit; \
-	pre-commit run ruff-format-check --hook-stage manual | grep -v "INFO"; \
-	pre-commit run ruff-check-manual --hook-stage manual | grep -v "INFO"; \
-	pre-commit run mypy-check --hook-stage manual | grep -v "INFO"
+	@status=0; \
+	uv run pytest -n auto -ra -v tests/unit || status=1; \
+	uv run pre-commit run ruff-format-check --hook-stage manual || status=1; \
+	uv run pre-commit run ruff-check-manual --hook-stage manual || status=1; \
+	uv run pre-commit run mypy-check --hook-stage manual || status=1; \
+	exit $$status
 
 .PHONY: server
 server: ## Spins up a local MS SQL Server instance for development. Docker-compose is required.


### PR DESCRIPTION
## Problem

Two independent issues made the `make` check targets unreliable.

**1. They could not run.** Targets invoked `pre-commit` directly, but `pre-commit` is installed into the project venv. The `pytest` targets in the same file already used `uv run`.

```
$ make ruff
/bin/sh: 2: pre-commit: not found
```

`make dev` had the same problem in its own last command (`pre-commit install`), so it failed on a fresh clone.

**2. Exit status came from `grep`, not the tool.** Every target piped through `| grep -v "INFO"`, so the pipeline's status was grep's:

| Situation | grep exit | `make` result |
|---|---|---|
| Check **fails**, prints a non-INFO line | 0 | **passes** (failure hidden) |
| Check **passes**, prints only INFO lines | 1 | **fails** (false alarm) |

In `test`, `pytest` was also joined with `;`, so only the final grep decided the status: a failing unit suite could not fail the target.

## Changes

- `uv run pre-commit` everywhere, including `make dev`.
- Dropped the `| grep -v "INFO"` pipes.
- `lint` and `test` accumulate a status, so every check still runs and any failure fails the target.

## Before / after

```
# before: staged lint error
$ make lint; echo $?
0          # wrong

# after
$ make lint; echo $?
2          # and mypy still ran after ruff failed
```

Clean tree still exits 0.

## Note

`make lint` remains a no-op when nothing is staged, since `pre-commit run` without `--all-files` only sees staged files. That is the documented intent ("against staged changes") and is unchanged here, but it is worth knowing: it can read as "passing" when nothing was checked. Use `make all` for the full sweep.
