### PR TITLE
ci: add a lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,44 @@
+---
+name: Lint
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - v*
+  pull_request:
+    branches:
+      - master
+      - v*
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9
+        with:
+          enable-cache: true
+
+      # The hook environments (ruff, mypy, yamllint) dominate this job's
+      # runtime. They are rebuilt only when the pinned hook revisions change.
+      - name: Cache pre-commit environments
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-py3.11-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      # SKIP omits the hooks that only make sense on a developer's machine.
+      - name: Run pre-commit
+        run: uvx pre-commit run --all-files --show-diff-on-failure --color always
+        env:
+          SKIP: no-commit-to-branch


### PR DESCRIPTION
## Problem

Lint and type checks ran only through the pre-commit.ci app. There was no repo-defined workflow for them.

- Nothing in the repo declares lint as a check, so it cannot be made a required status alongside `unit-tests` / `integration-tests`.
- Forks and contributors without the app enabled get no lint gate at all.
- The lint gate is invisible in the workflow list, so its absence is easy to miss.

## Changes

- Adds a `Lint` workflow running `pre-commit run --all-files --show-diff-on-failure` on push and PR to `master` / `v*`, matching the existing test workflows' triggers.
- Skips `no-commit-to-branch`, which only makes sense on a developer's machine.
- Runs pre-commit via `uvx`, consistent with the uv-based installs in `unit-tests` and `integration-tests`.
- Deliberately does **not** install the project or its dev group. The job only needs the hooks, so there is no reason to pull `dbt-core`, `pyodbc` and `mssql-python`.
- Caches hook environments on the pinned revisions in `.pre-commit-config.yaml`. Building the ruff/mypy/yamllint envs is where this job spends most of its time, so it is rebuilt only when those revisions change.
- Read-only permissions, no container needed.

## Before / after

| | Before | After |
|---|---|---|
| Lint on PRs | pre-commit.ci app only | app plus a repo workflow |
| Can be a required check | no | yes |
| Works on forks without the app | no | yes |

## Testing

`SKIP=no-commit-to-branch pre-commit run --all-files` passes on current master (all 16 hooks). `uvx pre-commit` resolves and runs locally.

This is additive and does not remove pre-commit.ci, which still handles autoupdate and autofix commits. If the duplication is unwanted, the app's checks can be narrowed separately.
