### PR TITLE
Raise compiler error for sql_header config with redirect to pre_hooks/query_options

### DIFF
--- a/dbt/include/sqlserver/macros/relations/views/create.sql
+++ b/dbt/include/sqlserver/macros/relations/views/create.sql
@@ -6,6 +6,14 @@
         {{ raise_if_query_options_set('view materializations (SQL Server does not accept OPTION on CREATE VIEW)') }}
     {%- endif -%}
 
+    {%- if config.get('sql_header') -%}
+        {{ exceptions.raise_compiler_error(
+            "sql_header is not supported on SQL Server. "
+            "CREATE VIEW must be the first statement in a batch, so sql_header cannot run in the same query. "
+            "Use pre_hooks for pre-model SQL or query_options for session-level SET options (e.g. query_options={'NOCOUNT': 'ON'})."
+        ) }}
+    {%- endif -%}
+
     {{ get_use_database_sql(relation.database) }}
     {% set contract_config = config.get('contract') %}
     {% if contract_config.enforced %}

--- a/tests/functional/adapter/mssql/test_sql_header.py
+++ b/tests/functional/adapter/mssql/test_sql_header.py
@@ -1,0 +1,61 @@
+"""Functional tests for the sql_header guard — sql_header is not supported on SQL Server
+because CREATE VIEW must be the first statement in a query batch."""
+
+import pytest
+
+from dbt.tests.util import run_dbt
+
+# ---------------------------------------------------------------------------
+# sql_header via config block
+# ---------------------------------------------------------------------------
+
+table_config_model_sql = """
+{{ config(materialized='table', sql_header='SET NOCOUNT ON;') }}
+select 1 as id
+"""
+
+view_config_model_sql = """
+{{ config(materialized='view', sql_header='SET NOCOUNT ON;') }}
+select 1 as id
+"""
+
+# ---------------------------------------------------------------------------
+# sql_header via set_sql_header macro
+# ---------------------------------------------------------------------------
+
+table_macro_model_sql = """
+{{ config(materialized='table') }}
+{% call set_sql_header(config) %}
+SET NOCOUNT ON;
+{%- endcall %}
+select 1 as id
+"""
+
+view_macro_model_sql = """
+{{ config(materialized='view') }}
+{% call set_sql_header(config) %}
+SET NOCOUNT ON;
+{%- endcall %}
+select 1 as id
+"""
+
+
+class TestSqlHeaderRejected:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table_config.sql": table_config_model_sql,
+            "view_config.sql": view_config_model_sql,
+            "table_macro.sql": table_macro_model_sql,
+            "view_macro.sql": view_macro_model_sql,
+        }
+
+    def test_all_rejected(self, project):
+        """All four sql_header variants (table/view x config/macro) must error
+        with a clear compiler message pointing to pre_hooks and query_options."""
+        results = run_dbt(["run"], expect_pass=False)
+        assert len(results) == 4
+
+        statuses = {r.node.name: r.status for r in results}
+        for name in ["table_config", "view_config", "table_macro", "view_macro"]:
+            assert statuses[name] == "error", f"{name} should have errored, got {statuses[name]}"


### PR DESCRIPTION
Closes #562

``sql_header` cannot work on SQL Server because `CREATE VIEW` must be the first statement in a query batch — advisory SQL (SET, DECLARE) cannot precede it in the same `EXEC()` call. Every materialization path in the adapter routes model SQL through a temp view, so there's no way to inject a header into the same batch.

Instead of silently ignoring the config, this adds a guard in `sqlserver__create_view_as` (the single choke point for all materializations) that raises a compiler error:

```
sql_header is not supported on SQL Server.
CREATE VIEW must be the first statement in a batch, so sql_header cannot run in the same query.
Use pre_hooks for pre-model SQL or query_options for session-level SET options (e.g. query_options={'NOCOUNT': 'ON'}).
```

A functional test verifies the rejection for all four combinations (table/view × config/macro) in a single dbt run.