### PR TITLE
ci: run unit and integration tests on release branches

### DIFF
--- a/.github/workflows/integration-tests-sqlserver.yml
+++ b/.github/workflows/integration-tests-sqlserver.yml
@@ -6,6 +6,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
       - v*
+      - release/**
     paths:
       - 'dbt/**'
       - 'tests/functional/**'
@@ -20,6 +21,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
       - v*
+      - release/**
     paths:
       - 'dbt/**'
       - 'tests/functional/**'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,10 +6,12 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
       - v*
+      - release/**
   pull_request:
     branches:
       - master
       - v*
+      - release/**
   schedule:
     - cron: '0 22 * * 0'
 


### PR DESCRIPTION
Both workflows filter on `branches: [master, v*]`. GitHub matches the whole ref, so `v*` matches a branch literally named `v1.11` — not `release/v1.11`, which is the naming this repo uses.

The effect is that a pull request targeting a release branch runs pre-commit only. No unit tests, no integration matrix. Backports are therefore the least-tested changes in the repo despite shipping first: #791 and #794 have no test coverage at all right now, and the 1.11 release would ship those fixes validated solely by their master-side counterparts.

Adds `release/**` to the `push` and `pull_request` filters of `unit-tests.yml` and `integration-tests-sqlserver.yml`.

Stacked pull requests — where the base is a feature branch rather than `master` or a release branch — remain uncovered. That is not fixable with a branch filter, since the base can be any branch name; those are validated once rebased onto `master`, or by dispatching the workflow against the branch (`gh workflow run "Integration tests on SQL Server" --ref <branch>`).

No milestone: CI-only, ships with whatever release is current.