### PR TITLE
fix: quote openquery's server name via adapter.quote() instead of hand-formatted brackets

### DIFF
--- a/dbt/include/sqlserver/macros/utils/openquery.sql
+++ b/dbt/include/sqlserver/macros/utils/openquery.sql
@@ -17,5 +17,5 @@
             {{ exceptions.raise_compiler_error("openquery: query exceeds SQL Server OPENQUERY 8 KB limit (got " ~ (cleaned_sql | length) ~ " characters after escaping, max 8000). Use EXEC('...') AT <server> or a remote view/OPENROWSET for longer queries.") }}
         {%- endif -%}
     {%- endif -%}
-    OPENQUERY([{{ server_name }}], '{{ cleaned_sql }}')
+    OPENQUERY({{ adapter.quote(server_name) }}, '{{ cleaned_sql }}')
 {%- endmacro %}

--- a/tests/functional/adapter/mssql/test_openquery.py
+++ b/tests/functional/adapter/mssql/test_openquery.py
@@ -203,9 +203,9 @@ class TestOpenquery:
         return results
 
     def test_emits_openquery_and_returns_rows(self, project, _run_all):
-        """Happy path: bracketed server name, literal remote SQL, real rows."""
+        """Happy path: quoted server name, literal remote SQL, real rows."""
         sql = _find_compiled_sql(project, "basic_model.sql")
-        assert "OPENQUERY([LOCALLOOP], 'SELECT 1 AS id" in sql
+        assert 'OPENQUERY("LOCALLOOP", \'SELECT 1 AS id' in sql
         rows = project.run_sql(
             f"SELECT id, name FROM {project.test_schema}.basic_model ORDER BY id",
             fetch="all",
@@ -216,21 +216,21 @@ class TestOpenquery:
         """Quotes are doubled in the emitted SQL, and the remote literal
         round-trips to the value it's."""
         sql = _find_compiled_sql(project, "quotes_model.sql")
-        assert "OPENQUERY([LOCALLOOP], 'SELECT ''it''''s'' AS msg')" in sql
+        assert "OPENQUERY(\"LOCALLOOP\", 'SELECT ''it''''s'' AS msg')" in sql
         rows = project.run_sql(f"SELECT msg FROM {project.test_schema}.quotes_model", fetch="all")
         assert [row[0] for row in rows] == ["it's"]
 
     def test_carriage_returns_are_stripped_and_query_runs(self, project, _run_all):
         sql = _find_compiled_sql(project, "cr_model.sql")
         assert "\r" not in sql
-        assert "OPENQUERY([LOCALLOOP], 'SELECT 1" in sql
+        assert 'OPENQUERY("LOCALLOOP", \'SELECT 1' in sql
         rows = project.run_sql(f"SELECT id FROM {project.test_schema}.cr_model", fetch="all")
         assert [row[0] for row in rows] == [1]
 
     def test_max_length_boundary_compiles(self, project, _run_all):
         """Exactly 8000 escaped characters is allowed."""
         sql = _find_compiled_sql(project, "max_length_model.sql")
-        assert "OPENQUERY([LOCALLOOP], 'SELECT " in sql
+        assert 'OPENQUERY("LOCALLOOP", \'SELECT ' in sql
 
     @pytest.mark.parametrize(
         "model_name,expected",


### PR DESCRIPTION
## Summary

PR #790 landed `sqlserver__openquery` emitting `OPENQUERY([{{ server_name }}], ...)` — a hand-formatted bracket identifier. That trips the #785 guard (`test_macros_do_not_hand_format_identifiers`), which requires every macro-built identifier to go through `adapter.quote()` so generated SQL keeps one quoting style, and broke CI on master right after merge:

```
AssertionError: use adapter.quote() or the relation object so generated SQL keeps one quoting style (#785):
    openquery.sql:20 ([{{ ... }}]): OPENQUERY([{{ server_name }}], '{{ cleaned_sql }}')
```

## Fix

- `OPENQUERY([{{ server_name }}], ...)` → `OPENQUERY({{ adapter.quote(server_name) }}, ...)`. SQL Server accepts a double-quoted linked-server name under `QUOTED_IDENTIFIER ON`, the adapter's default.
- Updated `tests/functional/adapter/mssql/test_openquery.py`'s compiled-SQL assertions from `OPENQUERY([LOCALLOOP], ...)` to `OPENQUERY("LOCALLOOP", ...)`.

## Test plan

- [x] `pytest tests/unit/adapters/mssql/test_quote.py` — 60 passed, including the previously-failing `test_macros_do_not_hand_format_identifiers[openquery.sql]`
- [x] `pytest tests/unit` — 500 passed
- [x] `ruff check dbt/ tests/` — clean
- [x] `pytest tests/functional/adapter/mssql/test_openquery.py` against a live local SQL Server (loopback linked server) — 9 passed
- [x] pre-commit (ruff, ty) passed on commit