### PR TITLE
chore: simplify render_column_constraint

### DIFF
--- a/dbt/adapters/sqlserver/sqlserver_adapter.py
+++ b/dbt/adapters/sqlserver/sqlserver_adapter.py
@@ -544,16 +544,13 @@ class SQLServerAdapter(SQLAdapter):
     @available
     @classmethod
     def render_column_constraint(cls, constraint: ColumnLevelConstraint) -> Optional[str]:
-        rendered_column_constraint = None
-        if constraint.type == ConstraintType.not_null:
-            rendered_column_constraint = "not null "
-        else:
-            rendered_column_constraint = ""
+        """Render NOT NULL inline; every other constraint type renders empty.
 
-        if rendered_column_constraint:
-            rendered_column_constraint = rendered_column_constraint.strip()
-
-        return rendered_column_constraint
+        CHECK, UNIQUE, PRIMARY KEY and FOREIGN KEY are emitted separately as
+        ALTER TABLE ADD CONSTRAINT (sqlserver__build_model_constraints), so
+        they contribute nothing to the column DDL.
+        """
+        return "not null" if constraint.type == ConstraintType.not_null else ""
 
     @classmethod
     def render_model_constraint(cls, constraint: ModelLevelConstraint) -> Optional[str]:


### PR DESCRIPTION
## What

`render_column_constraint` built the string `"not null "` with a trailing space, then stripped the space back off. It now returns the value directly.

## Why

Both the space and the `.strip()` are left over from dbt-core's base method, which builds `f"not null {constraint_expression}"` and strips the trailing space when there is no expression. This override dropped the interpolation but kept the space and the strip, so neither did anything.

The method also had a dead `rendered_column_constraint = None` that was overwritten on the next line.

## Behaviour

Unchanged. `not_null` returns `not null` and every other constraint type returns an empty string, exactly as before. The generated column DDL is identical, including the trailing space that the fixtures in `tests/functional/adapter/dbt/test_constraints.py` expect.

No changelog entry, since nothing user-facing changes.

## Testing

`ruff check`, `ruff format --check`, `ty check` and the 500 unit tests all pass. Pre-commit passes on the commit.
