### PR TITLE
chore: simplify expand_column_types

### DIFF
--- a/dbt/adapters/sqlserver/sqlserver_adapter.py
+++ b/dbt/adapters/sqlserver/sqlserver_adapter.py
@@ -594,54 +594,67 @@ class SQLServerAdapter(SQLAdapter):
             _discard_pending_results(cursor)
         return int(row[0]) if row else 0
 
+    def _safe_expansion_allowed(self, current, max_rows: int) -> bool:
+        """Whether cross-family promotions may run against ``current``.
+
+        Requires the ``dbt_sqlserver_enable_safe_type_expansion`` behaviour
+        flag, then consults ``column_type_expansion_max_rows``, which carries
+        three kinds of value: ``-1`` disables the row-count check, ``0``
+        blocks safe expansion outright, and a positive N blocks it once
+        ``current`` holds more than N rows. Counting rows costs a query, so it
+        runs only when the flag is on and a positive limit is set.
+        """
+        if not self.behavior.dbt_sqlserver_enable_safe_type_expansion:
+            return False
+
+        if max_rows == -1:
+            return True
+
+        if max_rows == 0:
+            logger.info(
+                "Safe type expansion skipped for %s: column_type_expansion_max_rows is 0.",
+                current,
+            )
+            return False
+
+        row_count = self._get_row_count(current)
+        if row_count > max_rows:
+            logger.warning(
+                "Safe type expansion skipped for %s: "
+                "%s rows exceeds column_type_expansion_max_rows (%s). "
+                "Set column_type_expansion_max_rows=-1 to disable "
+                "this check, or increase the limit.",
+                current,
+                row_count,
+                max_rows,
+            )
+            return False
+
+        return True
+
     def expand_column_types(self, goal, current, max_rows: int = 1000000):
-        """Override to ensure we preserve nvarchar/nchar type family during
-        column expansion. Necessary same-family resizes (e.g. varchar size)
-        always proceed. Safe type expansions (cross-family promotions like
-        varchar -> nvarchar) are guarded by column_type_expansion_max_rows.
-        enable_safe_type_expansion is the future approach for widening."""
+        """Widen ``current``'s columns to match ``goal``, preserving the
+        nvarchar / nchar family.
+
+        Same-family resizes (a longer varchar) always proceed. Cross-family
+        promotions (varchar -> nvarchar) are opt-in and gated; see
+        ``_safe_expansion_allowed``.
+        """
 
         reference_columns = {c.name: c for c in self.get_columns_in_relation(goal)}
         target_columns = {c.name: c for c in self.get_columns_in_relation(current)}
 
-        enable_safe = self.behavior.dbt_sqlserver_enable_safe_type_expansion
-
-        row_count_exceeds = False
-        if enable_safe and max_rows != -1:
-            if max_rows == 0:
-                row_count_exceeds = True
-                logger.info(
-                    "Safe type expansion skipped for %s: column_type_expansion_max_rows is 0.",
-                    current,
-                )
-            else:
-                row_count = self._get_row_count(current)
-                if row_count > max_rows:
-                    row_count_exceeds = True
-                    logger.warning(
-                        "Safe type expansion skipped for %s: "
-                        "%s rows exceeds column_type_expansion_max_rows (%s). "
-                        "Set column_type_expansion_max_rows=-1 to disable "
-                        "this check, or increase the limit.",
-                        current,
-                        row_count,
-                        max_rows,
-                    )
+        safe_expansion_allowed = self._safe_expansion_allowed(current, max_rows)
 
         for column_name, reference_column in reference_columns.items():
             target_column = target_columns.get(column_name)
             if target_column is None:
                 continue
 
-            if target_column.can_expand_to(reference_column):
-                pass
-            elif (
-                enable_safe
-                and not row_count_exceeds
-                and target_column.can_expand_safe(reference_column)
+            if not (
+                target_column.can_expand_to(reference_column)
+                or (safe_expansion_allowed and target_column.can_expand_safe(reference_column))
             ):
-                pass
-            else:
                 continue
 
             if reference_column.is_string():


### PR DESCRIPTION
## What

Two changes to `expand_column_types`:

1. The row-count gate moves into a new `_safe_expansion_allowed` method.
2. The loop's two `pass` branches collapse into one guard.

## Why

The loop read like this:

```python
if target_column.can_expand_to(reference_column):
    pass
elif enable_safe and not row_count_exceeds and target_column.can_expand_safe(...):
    pass
else:
    continue
```

Two `pass` branches look like something happens in them. It is a `continue` guard written inside out, and `enable_safe and not row_count_exceeds` is a double negative you have to unpick on every read.

The function also did three jobs at once: fetch both column maps, work out the row-count gate with its own two log messages, then loop and alter. The gate is now one method that answers one question.

The three meanings of `column_type_expansion_max_rows` were also undocumented: `-1` disables the row-count check, `0` blocks safe expansion outright, and a positive N is a row threshold. That is now in the docstring.

## Behaviour

Unchanged. I compared the old and new gate across every combination of the behaviour flag, six `max_rows` values and six row counts (72 cases). All three of these match in every case:

- whether safe expansion is allowed
- whether the row-count query runs, so no extra round trip
- which log message is emitted

I also checked the loop guard over all eight combinations of its three inputs, confirming it evaluates the same predicates in the same short-circuit order, so `can_expand_safe` is still only called when `can_expand_to` returned false.

No changelog entry, since nothing user-facing changes.

## Testing

`ruff check`, `ruff format --check`, `ty check` and the 500 unit tests all pass, including the 44 in `test_expand_column_types.py` and `test_can_expand_to.py`.

The functional tests in `tests/functional/adapter/mssql/test_column_type_expansion.py` need a live SQL Server, which I could not run locally. CI covers them.
