### PR TITLE
test(openquery): bootstrap the loopback linked server, and stop rebuilding it per worker

### DIFF
--- a/devops/scripts/init_db.sh
+++ b/devops/scripts/init_db.sh
@@ -19,13 +19,13 @@ done
 
 for i in {1..50};
 do
-    /opt/mssql-tools/bin/sqlcmd -C -S localhost -U sa -P "${SA_PASSWORD}" -d TestDB -I -i init.sql
+    /opt/mssql-tools/bin/sqlcmd -C -S localhost -U sa -P "${SA_PASSWORD}" -d TestDB -I -i init.sql,linked_server.sql
     if [ $? -eq 0 ]
     then
-        echo "user creation completed"
+        echo "instance configuration completed"
         break
     else
-        echo "configuring users..."
+        echo "configuring instance..."
         sleep 1
     fi
 done

--- a/devops/scripts/linked_server.sql
+++ b/devops/scripts/linked_server.sql
@@ -1,0 +1,55 @@
+-- Loopback linked server for the OPENQUERY tests (tests/functional/adapter/
+-- mssql/test_openquery.py), run at instance bootstrap by init_db.sh. This is
+-- the only thing that creates it: the tests read it and skip when it is
+-- absent, they never provision it.
+--
+-- That is the point of the file. A linked server is instance-wide, so a test
+-- fixture that created and dropped its own raced every other caller on the
+-- instance - whoever dropped last pulled the server out from under a run
+-- still using it (Msg 7202). Setting it up once, with the instance, is what
+-- removes the shared state from the tests entirely.
+--
+-- It is separate from init.sql because it configures the instance rather than
+-- TestDB's users, and because the tests name it when they skip.
+--
+-- Two settings vary by engine version, keyed off the running instance so one
+-- script serves every server-<version> image:
+--
+--   Provider: MSOLEDBSQL only became a valid linked-server provider on Linux
+--   in 2019; 2017 (major 14) rejects it with Msg 7222 and needs SQLNCLI. SQL
+--   Server 2017 leaves extended support on 2027-10-12; drop that branch along
+--   with the 2017 CI leg after that date.
+--
+--   Cert trust: from 2025 (major 17) the provider negotiates encryption by
+--   default and the loopback presents the instance's self-signed certificate,
+--   so the engine's outbound handshake fails ("SSL Provider: The handle
+--   specified is invalid") without it. Sent only where needed, so 2019 and
+--   2022 configure identically.
+--
+-- @useself = 'true' maps the local login to the same-named remote login, so no
+-- password is embedded here. The IF NOT EXISTS guard is load-bearing rather
+-- than decorative: init_db.sh re-runs this file until it exits 0.
+IF NOT EXISTS (SELECT 1 FROM sys.servers WHERE name = 'LOCALLOOP')
+BEGIN
+    DECLARE @major int = CAST(SERVERPROPERTY('ProductMajorVersion') AS int);
+    DECLARE @provider sysname =
+        CASE WHEN @major <= 14 THEN 'SQLNCLI' ELSE 'MSOLEDBSQL' END;
+    DECLARE @provstr nvarchar(4000) =
+        CASE WHEN @major >= 17 THEN 'TrustServerCertificate=Yes' END;
+
+    EXEC sp_addlinkedserver
+        @server = 'LOCALLOOP',
+        @srvproduct = '',
+        @provider = @provider,
+        @provstr = @provstr,
+        @datasrc = '127.0.0.1,1433';
+
+    EXEC sp_addlinkedsrvlogin
+        @rmtsrvname = 'LOCALLOOP',
+        @useself = 'true',
+        @locallogin = NULL,
+        @rmtuser = NULL,
+        @rmtpassword = NULL;
+
+    EXEC sp_serveroption 'LOCALLOOP', 'rpc out', true;
+END

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,10 @@
 [pytest]
+# loadgroup schedules tests marked with @pytest.mark.xdist_group onto one
+# worker, and everything else exactly as the default 'load' does. Without it,
+# xdist hands out a class's tests individually and every worker that receives
+# one sets the class-scoped fixtures up again - for a class whose fixture runs
+# dbt, that is a whole extra `dbt run` per worker.
+addopts = --dist loadgroup
 filterwarnings =
     ignore:.*'soft_unicode' has been renamed to 'soft_str'*:DeprecationWarning
     ignore:unclosed file .*:ResourceWarning

--- a/tests/functional/adapter/mssql/test_openquery.py
+++ b/tests/functional/adapter/mssql/test_openquery.py
@@ -11,8 +11,9 @@ ONE dbt invocation covers every case. Eight models live in a single project:
    (see openquery.sql), so they surface as per-node errors while every other
    model in the same run still succeeds.
 
-The linked server is created before the run and dropped afterwards, leaving no
-residue. Requires a live SQL Server and permission to run sp_addlinkedserver.
+The loopback linked server these run against is instance-wide state, created
+once by devops/scripts/linked_server.sql when the instance is set up. Nothing
+here provisions it; where it is absent these tests skip.
 """
 
 import os
@@ -20,70 +21,6 @@ import os
 import pytest
 
 from dbt.tests.util import run_dbt
-
-# A linked server is instance-wide, so a fixed name collides when pytest-xdist
-# runs this class on more than one worker against the same SQL Server: the
-# setup below drops-and-recreates, and the teardown drops outright, so one
-# worker pulls the server out from under another mid-run. The victim's models
-# then fail with Msg 7202 ("Could not find server ... in sys.servers") even
-# though its own fixture verified the server existed moments earlier - the
-# creator sees its own row, the other worker's connection does not.
-#
-# One name per worker process keeps them apart. It is stable across reruns
-# (unlike a uuid), so the IF EXISTS guard below still cleans up a server left
-# behind by a crashed run rather than leaking a new one each time.
-_PLACEHOLDER_SERVER_NAME = "LOCALLOOP"
-_LINKED_SERVER_NAME = "{}_{}".format(
-    _PLACEHOLDER_SERVER_NAME,
-    os.environ.get("PYTEST_XDIST_WORKER", "main").upper(),
-)
-
-
-def _for_this_worker(sql: str) -> str:
-    """Point SQL written against the placeholder name at this worker's server."""
-    return sql.replace(_PLACEHOLDER_SERVER_NAME, _LINKED_SERVER_NAME)
-
-
-def _create_linked_server_sql(major_version: int) -> str:
-    """Loopback linked server. Two settings vary by engine version.
-
-    Provider: MSOLEDBSQL only became a valid linked-server provider on Linux in
-    2019; 2017 rejects it with Msg 7222 and needs SQLNCLI.
-
-    Cert trust: from 2025 the provider negotiates encryption by default and the
-    loopback presents the instance's self-signed certificate, so the engine's
-    outbound handshake fails ("SSL Provider: The handle specified is invalid")
-    without it. Sent only where needed, so 2019/2022 generate identical SQL.
-
-    useself=true maps the local login to the same-named remote login, so no
-    password is embedded here.
-    """
-    # SQL Server 2017 leaves extended support on 2027-10-12; drop this branch
-    # and the 2017 CI leg after that date.
-    provider = "SQLNCLI" if major_version <= 14 else "MSOLEDBSQL"
-    provstr = "\n    @provstr = 'TrustServerCertificate=Yes'," if major_version >= 17 else ""
-    return f"""
-IF EXISTS (SELECT 1 FROM sys.servers WHERE name = '{_LINKED_SERVER_NAME}')
-    EXEC sp_dropserver '{_LINKED_SERVER_NAME}', 'droplogins';
-EXEC sp_addlinkedserver
-    @server = '{_LINKED_SERVER_NAME}',
-    @srvproduct = '',
-    @provider = '{provider}',{provstr}
-    @datasrc = '127.0.0.1,1433';
-EXEC sp_addlinkedsrvlogin
-    @rmtsrvname = '{_LINKED_SERVER_NAME}',
-    @useself = 'true',
-    @locallogin = NULL,
-    @rmtuser = NULL,
-    @rmtpassword = NULL;
-EXEC sp_serveroption '{_LINKED_SERVER_NAME}', 'rpc out', true;
-"""
-
-
-_DROP_LINKED_SERVER_SQL = f"""
-IF EXISTS (SELECT 1 FROM sys.servers WHERE name = '{_LINKED_SERVER_NAME}')
-    EXEC sp_dropserver '{_LINKED_SERVER_NAME}', 'droplogins';
-"""
 
 
 def _find_compiled_sql(project, filename: str) -> str:
@@ -181,39 +118,41 @@ class TestOpenquery:
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            name: _for_this_worker(body)
-            for name, body in {
-                "basic_model.sql": basic_sql,
-                "quotes_model.sql": quotes_sql,
-                "cr_model.sql": cr_sql,
-                "max_length_model.sql": max_length_sql,
-                "empty_server_model.sql": empty_server_sql,
-                "none_server_model.sql": none_server_sql,
-                "empty_remote_model.sql": empty_remote_sql,
-                "too_long_model.sql": too_long_sql,
-            }.items()
+            "basic_model.sql": basic_sql,
+            "quotes_model.sql": quotes_sql,
+            "cr_model.sql": cr_sql,
+            "max_length_model.sql": max_length_sql,
+            "empty_server_model.sql": empty_server_sql,
+            "none_server_model.sql": none_server_sql,
+            "empty_remote_model.sql": empty_remote_sql,
+            "too_long_model.sql": too_long_sql,
         }
 
     @pytest.fixture(scope="class")
     def _linked_server(self, project):
-        major_version = int(
-            project.run_sql(
-                "SELECT CAST(SERVERPROPERTY('ProductMajorVersion') AS int)", fetch="one"
-            )[0]
-        )
-        project.run_sql(_create_linked_server_sql(major_version))
+        """Require LOCALLOOP; never create it.
+
+        Creating one from here is what this class stopped doing: a linked
+        server is instance-wide, so a fixture that provisioned its own raced
+        every other caller on the instance, and dropping it pulled the server
+        out from under runs still using it (Msg 7202). Reading is the whole
+        contract.
+
+        Absent, these skip rather than fail. An instance may predate
+        devops/scripts/linked_server.sql - a CI image published before it -
+        or be one the adapter is merely pointed at, and Azure SQL Database
+        cannot have a linked server at all.
+        """
         rows = project.run_sql(
-            f"SELECT name FROM sys.servers WHERE name = '{_LINKED_SERVER_NAME}'",
-            fetch="all",
+            "SELECT name FROM sys.servers WHERE name = 'LOCALLOOP'", fetch="all"
         )
-        assert len(rows) == 1 and rows[0][0] == _LINKED_SERVER_NAME
-        yield
-        project.run_sql(_DROP_LINKED_SERVER_SQL)
-        left = project.run_sql(
-            f"SELECT COUNT(*) FROM sys.servers WHERE name = '{_LINKED_SERVER_NAME}'",
-            fetch="one",
-        )
-        assert left[0] == 0
+        if not rows:
+            pytest.skip(
+                "No LOCALLOOP linked server on this instance. It is created at "
+                "bootstrap by devops/scripts/linked_server.sql; an instance not "
+                "built from devops/server.Dockerfile needs it added by hand."
+            )
+        assert rows[0][0] == "LOCALLOOP"
 
     @pytest.fixture(scope="class")
     def _run_all(self, project, _linked_server):
@@ -228,7 +167,7 @@ class TestOpenquery:
     def test_emits_openquery_and_returns_rows(self, project, _run_all):
         """Happy path: quoted server name, literal remote SQL, real rows."""
         sql = _find_compiled_sql(project, "basic_model.sql")
-        assert _for_this_worker('OPENQUERY("LOCALLOOP", \'SELECT 1 AS id') in sql
+        assert 'OPENQUERY("LOCALLOOP", \'SELECT 1 AS id' in sql
         rows = project.run_sql(
             f"SELECT id, name FROM {project.test_schema}.basic_model ORDER BY id",
             fetch="all",
@@ -239,21 +178,21 @@ class TestOpenquery:
         """Quotes are doubled in the emitted SQL, and the remote literal
         round-trips to the value it's."""
         sql = _find_compiled_sql(project, "quotes_model.sql")
-        assert _for_this_worker("OPENQUERY(\"LOCALLOOP\", 'SELECT ''it''''s'' AS msg')") in sql
+        assert "OPENQUERY(\"LOCALLOOP\", 'SELECT ''it''''s'' AS msg')" in sql
         rows = project.run_sql(f"SELECT msg FROM {project.test_schema}.quotes_model", fetch="all")
         assert [row[0] for row in rows] == ["it's"]
 
     def test_carriage_returns_are_stripped_and_query_runs(self, project, _run_all):
         sql = _find_compiled_sql(project, "cr_model.sql")
         assert "\r" not in sql
-        assert _for_this_worker('OPENQUERY("LOCALLOOP", \'SELECT 1') in sql
+        assert 'OPENQUERY("LOCALLOOP", \'SELECT 1' in sql
         rows = project.run_sql(f"SELECT id FROM {project.test_schema}.cr_model", fetch="all")
         assert [row[0] for row in rows] == [1]
 
     def test_max_length_boundary_compiles(self, project, _run_all):
         """Exactly 8000 escaped characters is allowed."""
         sql = _find_compiled_sql(project, "max_length_model.sql")
-        assert _for_this_worker('OPENQUERY("LOCALLOOP", \'SELECT ') in sql
+        assert 'OPENQUERY("LOCALLOOP", \'SELECT ' in sql
 
     @pytest.mark.parametrize(
         "model_name,expected",

--- a/tests/functional/adapter/mssql/test_openquery.py
+++ b/tests/functional/adapter/mssql/test_openquery.py
@@ -107,8 +107,14 @@ select {{ sqlserver__openquery('LOCALLOOP', 'SELECT ' ~ 'x' * 8001) }} as result
 """
 
 
+@pytest.mark.xdist_group("openquery")
 class TestOpenquery:
     """One project, ONE `dbt run`, every case.
+
+    The xdist_group mark is what makes that true under `-n auto`: it keeps all
+    of these on one worker, so the class-scoped fixtures below - the project,
+    the linked server, and the dbt invocation itself - are set up once rather
+    than once per worker that happens to receive a test.
 
     `dbt run` (unlike `dbt compile`) records per-node errors instead of
     re-raising, so the four invalid models come back as status="error" results


### PR DESCRIPTION
Closes #833.

Replaces the per-worker linked-server machinery from 8e709ad with a server created once, where the instance is set up. **Nothing under `tests/` creates or drops a linked server any more** — the fixture reads `sys.servers` and skips when the server is absent.

## The problem

A linked server is instance-wide, so a fixture that drops and recreates one races every other caller on the same instance — whoever drops last pulls the server out from under a run still using it (Msg 7202). 8e709ad worked around that by giving each pytest-xdist worker its own name (`LOCALLOOP_GW0`, ...) and rewriting a `LOCALLOOP` placeholder through every model body and every emitted-SQL assertion. That stops the collision, but it is a lot of machinery for a server that never varies per test, and each worker still built and dropped its own.

The fix is to take the tests out of that business entirely rather than to name around it.

## What changed

**`devops/scripts/linked_server.sql`** (new) creates `LOCALLOOP` at bootstrap and is the only thing that ever creates it. `init_db.sh` runs it alongside `init.sql`. The two settings that vary by engine version are keyed off `SERVERPROPERTY`, since one script serves all four `server-<version>` images: `SQLNCLI` on 2017 (major 14), which rejects `MSOLEDBSQL` on Linux with Msg 7222, and `TrustServerCertificate=Yes` from 2025 (major 17), where the provider negotiates encryption and the loopback presents the instance's self-signed certificate. It is a file of its own rather than more of `init.sql` because it configures the instance rather than TestDB's users, and because the skip message names it.

**`test_openquery.py`** writes `LOCALLOOP` directly again — no per-worker names, no placeholder rewriting, no create, no teardown. The fixture is a `SELECT` against `sys.servers` and a skip.

Skipping, rather than failing, is the honest response to a missing server now that no test can fix one: an instance may predate the bootstrap script, or be one the adapter is merely pointed at, and Azure SQL Database cannot have a linked server at all. The message names `devops/scripts/linked_server.sql` so it is actionable.

## What this costs, and it is worth stating plainly

Integration CI takes its SQL Server from the prebuilt `ghcr.io/dbt-msft/dbt-sqlserver:server-<version>` tags, and `publish-docker.yml` only rebuilds those on push to `master` under `devops/**`. Every published image today predates this script, so:

- **on this PR, the nine openquery tests will skip**, not run;
- **on `master` immediately after merge they will most likely skip too**, since `publish-docker` and the integration matrix trigger on the same push and race;
- the next integration run after the images land has them passing again.

That is a real, if brief, gap in coverage for this macro, and the trade for never provisioning instance-wide state from a test. Worth a follow-up once the images are out: make a missing server a hard failure on the `ci_sql_server` profile specifically, where the instance is ours and always bootstrapped, so a broken bootstrap cannot hide behind a green run. Say the word and I will file it.

## Also here: four workers, four `dbt run`s

`ONE dbt invocation covers every case`, this file's opening line, was not true under `-n auto`. The default `--dist load` hands out tests individually, so all four workers received some of the nine and each set the class-scoped fixtures up again — four dbt projects, four `dbt run`s building the same eight models into four schemas. Wall clock hid it (the copies run in parallel), but the server did four times the work on every leg of a 16-job matrix. `--dist loadgroup` in `pytest.ini` plus an `xdist_group` mark pins the class to one worker; `loadgroup` treats unmarked tests exactly as `load` does, so no other test's scheduling moves. #834 tracks auditing the rest of the suite for the same problem.

## Verification

Bootstrap, by building `server.Dockerfile` at each version and reading `sys.servers` plus a live `OPENQUERY` round-trip through the created server:

| Image | major | provider | provider_string | round-trip |
|---|---|---|---|---|
| 2017 | 14 | `SQLNCLI` | `NULL` | ✅ |
| 2022 | 16 | `MSOLEDBSQL` | `NULL` | ✅ |
| 2025 | 17 | `MSOLEDBSQL` | `TrustServerCertificate=Yes` | ✅ |

2019 takes the same branch as 2022 and was not built separately. The 2017 leg doubles as the check on the oldest `sqlcmd` this repo runs against, which is the one that has to accept `-i init.sql,linked_server.sql`. Re-running against an already-initialized instance exits 0 and changes nothing.

Tests, against a local 2022 instance: 9 passed at `-n 4` with the server present; 9 skipped with it dropped, naming `linked_server.sql`, and nothing created behind them. Grouping: all 9 report from `gw0` at `-n 4`, against 2/2/3/2 across four workers before. Full functional suite on the `user` profile: 356 passed, 48 skipped, 2 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
